### PR TITLE
fix: add format: secret-ref to slackTokenRef field

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ curl -X POST http://127.0.0.1:3100/api/plugins/install \
 2. Add the `chat:write` bot scope
 3. Enable **Interactivity** and point the Request URL to your Paperclip host's `slack-interactivity` webhook endpoint
 4. Install the app to your workspace and copy the Bot OAuth Token
-5. Store the token in your Paperclip secret provider
-6. Install the plugin and configure the secret reference + channel ID
+5. In Paperclip, go to **Settings → Secrets** and create a new secret with your Bot OAuth Token. Copy the secret UUID.
+6. Install the plugin and configure the secret UUID in the `slackTokenRef` field + your default channel ID
 
 ## Configuration
 
@@ -173,6 +173,14 @@ The plugin registers these tools that agents can call:
 | `register_watch` | 5 | Register an event watch that triggers an agent on matching events |
 | `remove_watch` | 5 | Remove a registered event watch |
 | `list_watch_templates` | 5 | List built-in watch templates for common use cases |
+
+## Migration
+
+### v2.0.1
+
+The `slackTokenRef` field now declares `format: "secret-ref"`, which is required for Paperclip to collect and resolve secret references at activation time. Previously, the field was a plain `string` with no format annotation, causing plugin activation to fail with `Invalid secret reference`.
+
+**If you installed v2.0.0:** you must re-configure the plugin. Go to **Settings → Secrets**, create a secret with your Slack Bot OAuth Token, and paste the resulting secret UUID into the `slackTokenRef` field in the plugin configuration. Raw token strings are no longer accepted in this field.
 
 ## Development
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,5 @@
 export const PLUGIN_ID = "paperclip-plugin-slack";
-export const PLUGIN_VERSION = "2.0.0";
+export const PLUGIN_VERSION = "2.0.1";
 
 export const WEBHOOK_KEYS = {
   slackEvents: "slack-events",

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -47,8 +47,9 @@ const manifest: PaperclipPluginManifestV1 = {
     properties: {
       slackTokenRef: {
         type: "string",
+        format: "secret-ref",
         title: "Slack Bot Token (secret reference)",
-        description: "Reference to the Slack Bot OAuth token stored in your secret provider.",
+        description: "Secret UUID for your Slack Bot OAuth token. Create the secret in Settings → Secrets, then paste its UUID here.",
         default: DEFAULT_CONFIG.slackTokenRef,
       },
       defaultChannelId: {


### PR DESCRIPTION
## Summary

- `slackTokenRef` was declared as `type: "string"` without `format: "secret-ref"`, causing plugin activation to fail with `Invalid secret reference`
- `collectSecretRefPaths()` requires `format: "secret-ref"` to include the field in secret path collection
- Bumps version to `2.0.1` and adds a `## Migration` section in README for users who entered raw tokens

## Test plan

- [ ] Verify the `slackTokenRef` field in `src/manifest.ts` has `format: "secret-ref"`
- [ ] Verify `PLUGIN_VERSION` in `src/constants.ts` is `"2.0.1"`
- [ ] Verify README `## Setup` step 5 references creating a secret in Settings → Secrets
- [ ] Verify README `## Migration` → `### v2.0.1` section explains the re-configuration requirement
- [ ] Install plugin v2.0.1, create a secret for the Slack token, enter the UUID in `slackTokenRef` — confirm activation succeeds without `Invalid secret reference`

🤖 Generated with [Claude Code](https://claude.com/claude-code)