### PR TITLE
chore: fix plugin install ui error

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -188,16 +188,6 @@ const manifest: PaperclipPluginManifestV1 = {
       description: "Receives button click payloads from interactive messages (approve/reject/escalation/handoff/discussion/command).",
     },
   ],
-  ui: {
-    slots: [
-      {
-        type: "settingsPage",
-        id: SLOT_IDS.settingsPage,
-        displayName: "Slack Settings",
-        exportName: EXPORT_NAMES.settingsPage,
-      },
-    ],
-  },
 };
 
 export default manifest;


### PR DESCRIPTION
### Problem

<img width="665" height="629" alt="Screenshot 2026-03-24 at 1 30 13 PM" src="https://github.com/user-attachments/assets/6f4e66a8-78c9-4899-b45d-3d3e808ef7b0" />

`Failed to install plugin: Invalid plugin manifest: entrypoints.ui: entrypoints.ui is required when ui.slots or ui.launchers are declared`

### Fix

Remove ui.slots declaration from manifest (no UI source exists), which causes 'entrypoints.ui is required' validation error on install