### PR TITLE
fix: add missing runWorker() call

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,5 +1,6 @@
 import {
   definePlugin,
+  runWorker,
   type PluginContext,
   type PluginEvent,
   type PluginWebhookInput,
@@ -345,7 +346,7 @@ async function handleApproveCommand(ctx: PluginContext, responseUrl: string, app
 
 // --- Plugin definition ---
 
-export default definePlugin({
+const plugin = definePlugin({
   async setup(ctx) {
     const rawConfig = await ctx.config.get();
     const config = rawConfig as unknown as SlackConfig;
@@ -1422,3 +1423,6 @@ export default definePlugin({
     return { status: "ok" };
   },
 });
+
+export default plugin;
+runWorker(plugin, import.meta.url);


### PR DESCRIPTION
## Summary

- Add `runWorker(plugin, import.meta.url)` call at the end of `src/worker.ts`
- Without it, the worker process exits immediately with `code=0` because the JSON-RPC bridge to the host is never started

## Context

The SDK (`@paperclipai/plugin-sdk >= 2026.318.0`) requires an explicit `runWorker()` call to start the stdin/stdout JSON-RPC communication channel between the worker and the Paperclip host. Without this call, the process imports, creates the plugin object via `definePlugin()`, and exits — nothing keeps it alive.

Fixes #6

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` — 97/97 tests pass
- [x] `pnpm build` compiles without errors
- [x] Tested manually: `npx paperclipai plugin install ./` → plugin reaches `ready` status