### PR TITLE
chore: bump version to 2.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paperclip-plugin-slack",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "type": "module",
   "main": "./dist/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bumps version to 2.0.6 so the runWorker() fix from #7 is included in the next npm publish
- 2.0.5 was published before #7 merged

## Test plan
- [ ] Merge and run `npm publish`
- [ ] Verify `npm view paperclip-plugin-slack version` shows 2.0.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)