### PR TITLE
Keep Slack manifest version aligned with 2.0.6 release

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,5 @@
 export const PLUGIN_ID = "paperclip-plugin-slack";
-export const PLUGIN_VERSION = "2.0.5";
+export const PLUGIN_VERSION = "2.0.6";
 
 export const WEBHOOK_KEYS = {
   slackEvents: "slack-events",


### PR DESCRIPTION
## Summary
- update `PLUGIN_VERSION` to match the released package version
- keep the manifest-reported version aligned with what operators see in Paperclip

## Why
Paperclip reads the plugin manifest version during local-path upgrades. With the stale constant, successful upgrades still looked stuck on `2.0.5`.

Fixes #11

## Verification
- `npm run build`