### PR TITLE
Add Slack request signature verification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,17 @@
 {
   "name": "paperclip-plugin-slack",
-  "version": "2.0.3",
+  "version": "2.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "paperclip-plugin-slack",
-      "version": "2.0.3",
+      "version": "2.0.6",
+      "license": "MIT",
       "devDependencies": {
         "@paperclipai/plugin-sdk": "^2026.318.0",
         "@paperclipai/shared": "^2026.318.0",
+        "@types/node": "^25.5.2",
         "typescript": "^5.7.0",
         "vitest": "^3.0.0"
       },
@@ -602,9 +604,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -619,9 +618,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -636,9 +632,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -653,9 +646,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -670,9 +660,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -687,9 +674,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -704,9 +688,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -721,9 +702,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -738,9 +716,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -755,9 +730,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -772,9 +744,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -789,9 +758,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -806,9 +772,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -923,6 +886,16 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
+      "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
@@ -1495,6 +1468,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "7.3.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@paperclipai/plugin-sdk": "^2026.318.0",
     "@paperclipai/shared": "^2026.318.0",
+    "@types/node": "^25.5.2",
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"
   },

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -37,6 +37,7 @@ export const STATE_KEYS = {
 
 export const DEFAULT_CONFIG = {
   slackTokenRef: "",
+  slackSigningSecretRef: "",
   defaultChannelId: "",
   approvalsChannelId: "",
   errorsChannelId: "",

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -52,6 +52,13 @@ const manifest: PaperclipPluginManifestV1 = {
         description: "Secret UUID for your Slack Bot OAuth token. Create the secret in Settings → Secrets, then paste its UUID here.",
         default: DEFAULT_CONFIG.slackTokenRef,
       },
+      slackSigningSecretRef: {
+        type: "string",
+        format: "secret-ref",
+        title: "Slack Signing Secret (secret reference)",
+        description: "Secret UUID for your Slack app's Signing Secret. Required to verify that incoming webhooks are genuinely from Slack.",
+        default: DEFAULT_CONFIG.slackSigningSecretRef,
+      },
       defaultChannelId: {
         type: "string",
         title: "Default Slack Channel ID",
@@ -149,7 +156,7 @@ const manifest: PaperclipPluginManifestV1 = {
         default: DEFAULT_CONFIG.maxAgentsPerThread,
       },
     },
-    required: ["slackTokenRef", "defaultChannelId"],
+    required: ["slackTokenRef", "slackSigningSecretRef", "defaultChannelId"],
   },
   jobs: [
     {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 export type SlackConfig = {
   slackTokenRef: string;
+  slackSigningSecretRef: string;
   defaultChannelId: string;
   approvalsChannelId: string;
   errorsChannelId: string;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,3 +1,4 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
 import {
   definePlugin,
   runWorker,
@@ -55,6 +56,41 @@ let pluginCtx: PluginContext;
 let pluginToken: string;
 let pluginConfig: SlackConfig;
 let slackAdapter: SlackAdapter;
+
+// --- Slack signature verification ---
+
+let slackSigningSecret: string | null = null;
+
+function verifySlackSignature(
+  headers: Record<string, string | string[]>,
+  rawBody: string,
+): boolean {
+  if (!slackSigningSecret) return true; // skip if not configured
+
+  const timestamp = String(
+    headers["x-slack-request-timestamp"] ??
+    headers["X-Slack-Request-Timestamp"] ?? ""
+  );
+  const signature = String(
+    headers["x-slack-signature"] ??
+    headers["X-Slack-Signature"] ?? ""
+  );
+
+  if (!timestamp || !signature) return false;
+
+  // Reject requests older than 5 minutes to prevent replay attacks
+  const now = Math.floor(Date.now() / 1000);
+  if (Math.abs(now - Number(timestamp)) > 300) return false;
+
+  const baseString = `v0:${timestamp}:${rawBody}`;
+  const hmac = createHmac("sha256", slackSigningSecret)
+    .update(baseString)
+    .digest("hex");
+  const expected = `v0=${hmac}`;
+
+  if (expected.length !== signature.length) return false;
+  return timingSafeEqual(Buffer.from(expected), Buffer.from(signature));
+}
 
 // --- Helpers ---
 
@@ -365,6 +401,15 @@ const plugin = definePlugin({
 
     const token = await ctx.secrets.resolve(config.slackTokenRef);
     pluginToken = token;
+
+    // Resolve Slack signing secret for webhook signature verification
+    if (config.slackSigningSecretRef) {
+      try {
+        slackSigningSecret = await ctx.secrets.resolve(config.slackSigningSecretRef);
+      } catch {
+        ctx.logger.warn("Slack signing secret not configured — webhook signature verification disabled");
+      }
+    }
 
     // =========================================================================
     // PHASE 1: Escalation - using 3-arg ctx.tools.register with ToolRunContext
@@ -1221,7 +1266,14 @@ const plugin = definePlugin({
   // =========================================================================
 
   async onWebhook(input: PluginWebhookInput): Promise<void> {
+    // Verify Slack request signature (skip for url_verification challenge)
     const body = input.parsedBody as Record<string, unknown> | undefined;
+    const isVerificationChallenge = body?.type === "url_verification";
+
+    if (!isVerificationChallenge && !verifySlackSignature(input.headers, input.rawBody)) {
+      pluginCtx.logger.warn("Rejected webhook: invalid Slack signature");
+      return;
+    }
 
     // Slack Events API (url_verification + event callbacks)
     if (input.endpointKey === WEBHOOK_KEYS.slackEvents) {


### PR DESCRIPTION
## Summary

- Adds `X-Slack-Signature` verification to the `onWebhook` handler using HMAC-SHA256
- New required config field `slackSigningSecretRef` (secret-ref) for the Slack app's Signing Secret
- 5-minute timestamp window to prevent replay attacks
- Timing-safe comparison to prevent timing side-channel attacks
- Skips verification for `url_verification` challenges so initial Slack setup still works
- Graceful fallback: logs a warning if signing secret is not configured

## Motivation

The webhook endpoints currently accept any POST request without verifying it came from Slack. Anyone who discovers the webhook URL can forge events to invoke agents, create issues, or approve tasks. This is documented as a known gap in Slack's [webhook security guide](https://api.slack.com/authentication/verifying-requests-from-slack).

## Changes

| File | Change |
|------|--------|
| `src/worker.ts` | `verifySlackSignature()` + gating in `onWebhook()` + secret resolution in setup |
| `src/manifest.ts` | Added `slackSigningSecretRef` config field |
| `src/types.ts` | Added field to `SlackConfig` type |
| `src/constants.ts` | Added default value |
| `package.json` | Added `@types/node` dev dependency (for `node:crypto`) |

## Test plan

- [ ] Configure signing secret in Paperclip secrets, set `slackSigningSecretRef` in plugin config
- [ ] Verify legitimate Slack webhooks (slash commands, events, interactivity) are accepted
- [ ] Verify forged requests without valid signature are rejected (logged as warning)
- [ ] Verify `url_verification` challenge still works during Slack app setup
- [ ] Verify replay attacks (timestamp > 5 min old) are rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)