### PR TITLE
fix: dedupe notifier compose between fallback text and block body

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,6 +27,8 @@ export const STATE_KEYS = {
   handoff: (id: string) => `handoff-${id}`,
   slackChannel: "slack-channel",
   threadIssue: (id: string) => `thread-issue-${id}`,
+  threadGoal: (id: string) => `thread-goal-${id}`,
+  threadProject: (id: string) => `thread-project-${id}`,
   dailyCost: (date: string) => `daily-cost-${date}`,
   dailyAgentCosts: (date: string) => `daily-agent-costs-${date}`,
   firstRunNotified: (id: string) => `first-run-notified-${id}`,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -33,6 +33,7 @@ export const STATE_KEYS = {
   budgetAlert: (id: string, bucket: number) => `budget-alert-${id}-${bucket}`,
   watchRegistry: (ch: string, ts: string) => `watches_${ch}_${ts}`,
   commandRegistry: "custom-commands",
+  eventDedup: (id: string) => `event-dedup-${id}`,
 } as const;
 
 export const DEFAULT_CONFIG = {
@@ -44,6 +45,7 @@ export const DEFAULT_CONFIG = {
   escalationChatId: "",
   notifyOnIssueCreated: true,
   notifyOnIssueDone: true,
+  notifyOnIssueUpdated: true,
   notifyOnApprovalCreated: true,
   notifyOnAgentError: true,
   notifyOnAgentConnected: true,

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -43,6 +43,20 @@ const STATUS_KR: Record<string, string> = {
   cancelled: "취소",
 };
 
+// Agent name → Slack User ID mapping
+const AGENT_SLACK_UID: Record<string, string> = {
+  Kuromi: "U0AQMUV1BAM",
+  HelloKitty: "U0AQ4PME36F",
+  MyMelody: "U0AQEQNBM4L",
+  BadtzMaru: "U0AQ90MLZJS",
+  Cinnamoroll: "U0AQ4R8B4Q3",
+};
+
+function slackMention(name: string): string {
+  const uid = AGENT_SLACK_UID[name];
+  return uid ? `<@${uid}>` : name;
+}
+
 function contextFooter(timestamp?: string): Record<string, unknown> {
   const elements: Array<Record<string, unknown>> = [
     { type: "mrkdwn", text: ":paperclip: *Paperclip*" },
@@ -135,7 +149,7 @@ export function formatIssueCreated(event: PluginEvent): SlackMessage {
 
   // Fields block for metadata
   const fields: Array<{ type: string; text: string }> = [];
-  fields.push({ type: "mrkdwn", text: `*담당자*\n:bust_in_silhouette: ${assigneeName ?? "미할당"}` });
+  fields.push({ type: "mrkdwn", text: `*담당자*\n:bust_in_silhouette: ${assigneeName ? slackMention(assigneeName) : "미할당"}` });
   if (priorityKr) fields.push({ type: "mrkdwn", text: `*우선순위*\n${priorityEmoji} ${priorityKr}` });
   if (projectName) fields.push({ type: "mrkdwn", text: `*프로젝트*\n:file_folder: ${projectName}` });
   if (goalName) fields.push({ type: "mrkdwn", text: `*목표*\n:dart: ${goalName}` });
@@ -148,7 +162,7 @@ export function formatIssueCreated(event: PluginEvent): SlackMessage {
   blocks.push(contextFooter(event.occurredAt));
 
   return {
-    text: `${priorityEmoji} 새 이슈: ${identifier} - ${title} → ${assigneeName ?? "미할당"}`,
+    text: `${priorityEmoji} 새 이슈: ${identifier} - ${title} → ${assigneeName ? slackMention(assigneeName) : "미할당"}`,
     blocks,
   };
 }
@@ -164,7 +178,7 @@ export function formatIssueDone(event: PluginEvent): SlackMessage {
   const lines = [`:white_check_mark: *${identifier} 완료*`, `*${title}*`];
   if (description) lines.push(description.slice(0, 150));
   const meta: string[] = [];
-  if (assigneeName) meta.push(`:bust_in_silhouette: ${assigneeName}`);
+  if (assigneeName) meta.push(`:bust_in_silhouette: ${slackMention(assigneeName)}`);
   if (projectName) meta.push(`:file_folder: ${projectName}`);
   if (meta.length > 0) lines.push(meta.join(" · "));
 
@@ -199,7 +213,7 @@ export function formatIssueStatusChanged(event: PluginEvent): SlackMessage {
   if (title) lines.push(`*${title}*`);
   if (description) lines.push(description.slice(0, 150));
   const meta: string[] = [];
-  if (assigneeName) meta.push(`:bust_in_silhouette: ${assigneeName}`);
+  if (assigneeName) meta.push(`:bust_in_silhouette: ${slackMention(assigneeName)}`);
   if (projectName) meta.push(`:file_folder: ${projectName}`);
   if (meta.length > 0) lines.push(meta.join(" · "));
 
@@ -227,7 +241,7 @@ export function formatApprovalCreated(event: PluginEvent): SlackMessage {
   const issueIds = Array.isArray(p.issueIds) ? p.issueIds : [];
 
   const fields: Array<{ type: string; text: string }> = [];
-  if (agentName) fields.push({ type: "mrkdwn", text: `*요청 에이전트*\n:robot_face: ${agentName}` });
+  if (agentName) fields.push({ type: "mrkdwn", text: `*요청 에이전트*\n:robot_face: ${slackMention(agentName)}` });
   fields.push({ type: "mrkdwn", text: `*유형*\n\`${approvalType}\`` });
   if (issueIds.length > 0) {
     fields.push({ type: "mrkdwn", text: `*관련 이슈*\n${issueIds.join(", ")}` });
@@ -318,7 +332,7 @@ export function formatAgentError(event: PluginEvent): SlackMessage {
         type: "section",
         text: {
           type: "mrkdwn",
-          text: `:warning: *에이전트 에러*\n:robot_face: *${agentName}*\n\`\`\`${errorMessage.slice(0, 500)}\`\`\``,
+          text: `:warning: *에이전트 에러*\n:robot_face: ${slackMention(agentName)}\n\`\`\`${errorMessage.slice(0, 500)}\`\`\``,
         },
       },
       contextFooter(event.occurredAt),
@@ -337,7 +351,7 @@ export function formatAgentConnected(event: PluginEvent): SlackMessage {
         type: "section",
         text: {
           type: "mrkdwn",
-          text: `:white_check_mark: *에이전트 온라인*\n:robot_face: *${agentName}* 연결됨`,
+          text: `:white_check_mark: *에이전트 온라인*\n:robot_face: ${slackMention(agentName)} 연결됨`,
         },
       },
       contextFooter(event.occurredAt),
@@ -359,7 +373,7 @@ export function formatBudgetThreshold(event: PluginEvent): SlackMessage {
         type: "section",
         text: {
           type: "mrkdwn",
-          text: `:chart_with_upwards_trend: *예산 임계값 도달*\n:robot_face: *${agentName}* — *${pct}%* 사용 ($${spent} / $${budget})`,
+          text: `:chart_with_upwards_trend: *예산 임계값 도달*\n:robot_face: ${slackMention(agentName)} — *${pct}%* 사용 ($${spent} / $${budget})`,
         },
       },
       contextFooter(event.occurredAt),
@@ -379,7 +393,7 @@ export function formatOnboardingMilestone(event: PluginEvent): SlackMessage {
         type: "section",
         text: {
           type: "mrkdwn",
-          text: `:tada: *마일스톤 달성*\n:robot_face: *${agentName}* — ${milestone}`,
+          text: `:tada: *마일스톤 달성*\n:robot_face: ${slackMention(agentName)} — ${milestone}`,
         },
       },
       contextFooter(event.occurredAt),
@@ -397,7 +411,6 @@ export function formatDailyDigest(stats: {
   tasksCompleted: number;
   tasksCreated: number;
   agentsActive: number;
-  totalCost: string;
   topAgent: string;
   agentStats?: Record<string, { completed: number; inProgress: number; created: number }>;
   completedIssues?: IssueItem[];
@@ -416,7 +429,6 @@ export function formatDailyDigest(stats: {
         { type: "mrkdwn", text: `*:white_check_mark: 완료*\n${stats.tasksCompleted}건` },
         { type: "mrkdwn", text: `*:inbox_tray: 생성*\n${stats.tasksCreated}건` },
         { type: "mrkdwn", text: `*:robot_face: 활성 에이전트*\n${stats.agentsActive}명` },
-        { type: "mrkdwn", text: `*:moneybag: 비용*\n$${stats.totalCost}` },
       ],
     },
   ];
@@ -430,7 +442,7 @@ export function formatDailyDigest(stats: {
         if (s.completed > 0) parts.push(`✅${s.completed}`);
         if (s.inProgress > 0) parts.push(`🔧${s.inProgress}`);
         if (s.created > 0) parts.push(`📥${s.created}`);
-        return `:robot_face: *${name}* — ${parts.join(" ")}`;
+        return `:robot_face: ${slackMention(name)} — ${parts.join(" ")}`;
       });
     if (agentLines.length > 0) {
       blocks.push({ type: "divider" });
@@ -444,7 +456,7 @@ export function formatDailyDigest(stats: {
   // Completed issues list
   if (stats.completedIssues && stats.completedIssues.length > 0) {
     const lines = stats.completedIssues
-      .map((i) => `✅ *${i.identifier}* ${i.title.slice(0, 50)} — ${i.agentName}`)
+      .map((i) => `✅ *${i.identifier}* ${i.title.slice(0, 50)} — ${slackMention(i.agentName)}`)
       .join("\n");
     blocks.push({ type: "divider" });
     blocks.push({
@@ -456,7 +468,7 @@ export function formatDailyDigest(stats: {
   // In-progress issues list
   if (stats.inProgressIssues && stats.inProgressIssues.length > 0) {
     const lines = stats.inProgressIssues
-      .map((i) => `🔧 *${i.identifier}* ${i.title.slice(0, 50)} — ${i.agentName}`)
+      .map((i) => `🔧 *${i.identifier}* ${i.title.slice(0, 50)} — ${slackMention(i.agentName)}`)
       .join("\n");
     blocks.push({
       type: "section",
@@ -467,18 +479,18 @@ export function formatDailyDigest(stats: {
   if (stats.topAgent) {
     blocks.push({
       type: "section",
-      text: { type: "mrkdwn", text: `:trophy: *MVP:* ${stats.topAgent}` },
+      text: { type: "mrkdwn", text: `:trophy: *MVP:* ${slackMention(stats.topAgent)}` },
     });
   }
 
   blocks.push({ type: "divider" });
   blocks.push({
     type: "context",
-    elements: [{ type: "mrkdwn", text: ":paperclip: *Paperclip* — 2시간 활동 요약" }],
+    elements: [{ type: "mrkdwn", text: ":paperclip: *Paperclip* — 활동 요약" }],
   });
 
   return {
-    text: `팀 활동 요약: ${stats.tasksCompleted}건 완료, ${stats.tasksCreated}건 생성, $${stats.totalCost} 사용`,
+    text: `팀 활동 요약: ${stats.tasksCompleted}건 완료, ${stats.tasksCreated}건 생성`,
     blocks,
   };
 }
@@ -567,7 +579,7 @@ export function formatEscalationMessage(escalation: EscalationRecord): SlackMess
   });
 
   return {
-    text: `:sos: ${escalation.agentName ?? "에이전트"} 에스컬레이션: ${escalation.reason}`,
+    text: `:sos: ${escalation.agentName ? slackMention(escalation.agentName) : "에이전트"} 에스컬레이션: ${escalation.reason}`,
     blocks,
   };
 }

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -387,47 +387,99 @@ export function formatOnboardingMilestone(event: PluginEvent): SlackMessage {
   };
 }
 
+interface IssueItem {
+  identifier: string;
+  title: string;
+  agentName: string;
+}
+
 export function formatDailyDigest(stats: {
   tasksCompleted: number;
   tasksCreated: number;
   agentsActive: number;
   totalCost: string;
   topAgent: string;
+  agentStats?: Record<string, { completed: number; inProgress: number; created: number }>;
+  completedIssues?: IssueItem[];
+  inProgressIssues?: IssueItem[];
+  createdIssues?: IssueItem[];
 }): SlackMessage {
-  return {
-    text: `팀 활동 요약: ${stats.tasksCompleted}건 완료, $${stats.totalCost} 사용`,
-    blocks: [
-      {
-        type: "header",
-        text: { type: "plain_text", text: ":bar_chart: 팀 활동 요약" },
-      },
-      { type: "divider" },
-      {
+  const blocks: Array<Record<string, unknown>> = [
+    {
+      type: "header",
+      text: { type: "plain_text", text: ":bar_chart: 팀 활동 요약" },
+    },
+    { type: "divider" },
+    {
+      type: "section",
+      fields: [
+        { type: "mrkdwn", text: `*:white_check_mark: 완료*\n${stats.tasksCompleted}건` },
+        { type: "mrkdwn", text: `*:inbox_tray: 생성*\n${stats.tasksCreated}건` },
+        { type: "mrkdwn", text: `*:robot_face: 활성 에이전트*\n${stats.agentsActive}명` },
+        { type: "mrkdwn", text: `*:moneybag: 비용*\n$${stats.totalCost}` },
+      ],
+    },
+  ];
+
+  // Per-agent breakdown
+  if (stats.agentStats && Object.keys(stats.agentStats).length > 0) {
+    const agentLines = Object.entries(stats.agentStats)
+      .filter(([, s]) => s.completed > 0 || s.inProgress > 0 || s.created > 0)
+      .map(([name, s]) => {
+        const parts: string[] = [];
+        if (s.completed > 0) parts.push(`✅${s.completed}`);
+        if (s.inProgress > 0) parts.push(`🔧${s.inProgress}`);
+        if (s.created > 0) parts.push(`📥${s.created}`);
+        return `:robot_face: *${name}* — ${parts.join(" ")}`;
+      });
+    if (agentLines.length > 0) {
+      blocks.push({ type: "divider" });
+      blocks.push({
         type: "section",
-        fields: [
-          { type: "mrkdwn", text: `*:white_check_mark: 완료*\n${stats.tasksCompleted}건` },
-          { type: "mrkdwn", text: `*:inbox_tray: 생성*\n${stats.tasksCreated}건` },
-          { type: "mrkdwn", text: `*:robot_face: 활성 에이전트*\n${stats.agentsActive}명` },
-          { type: "mrkdwn", text: `*:moneybag: 비용*\n$${stats.totalCost}` },
-        ],
-      },
-      ...(stats.topAgent
-        ? [
-            {
-              type: "section" as const,
-              text: {
-                type: "mrkdwn" as const,
-                text: `:trophy: *MVP:* ${stats.topAgent}`,
-              },
-            },
-          ]
-        : []),
-      { type: "divider" },
-      {
-        type: "context",
-        elements: [{ type: "mrkdwn", text: ":paperclip: *Paperclip* — 2시간 활동 요약" }],
-      },
-    ],
+        text: { type: "mrkdwn", text: `*에이전트별 활동*\n${agentLines.join("\n")}` },
+      });
+    }
+  }
+
+  // Completed issues list
+  if (stats.completedIssues && stats.completedIssues.length > 0) {
+    const lines = stats.completedIssues
+      .map((i) => `✅ *${i.identifier}* ${i.title.slice(0, 50)} — ${i.agentName}`)
+      .join("\n");
+    blocks.push({ type: "divider" });
+    blocks.push({
+      type: "section",
+      text: { type: "mrkdwn", text: `*완료된 이슈*\n${lines}` },
+    });
+  }
+
+  // In-progress issues list
+  if (stats.inProgressIssues && stats.inProgressIssues.length > 0) {
+    const lines = stats.inProgressIssues
+      .map((i) => `🔧 *${i.identifier}* ${i.title.slice(0, 50)} — ${i.agentName}`)
+      .join("\n");
+    blocks.push({
+      type: "section",
+      text: { type: "mrkdwn", text: `*진행 중*\n${lines}` },
+    });
+  }
+
+  if (stats.topAgent) {
+    blocks.push({
+      type: "section",
+      text: { type: "mrkdwn", text: `:trophy: *MVP:* ${stats.topAgent}` },
+    });
+  }
+
+  blocks.push({ type: "divider" });
+  blocks.push({
+    type: "context",
+    elements: [{ type: "mrkdwn", text: ":paperclip: *Paperclip* — 2시간 활동 요약" }],
+  });
+
+  return {
+    text: `팀 활동 요약: ${stats.tasksCompleted}건 완료, ${stats.tasksCreated}건 생성, $${stats.totalCost} 사용`,
+    blocks,
   };
 }
 

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -57,6 +57,12 @@ function slackMention(name: string): string {
   return uid ? `<@${uid}>` : name;
 }
 
+/** Format issue identifier as clickable Slack link: <url|DGG-123> */
+function issueLink(identifier: string, entityId?: string): string {
+  const id = entityId ?? identifier;
+  return `<${dashboardBase}/DGG/issues/${identifier}|${identifier}>`;
+}
+
 // --- Execution result extraction ---
 
 const EXEC_RESULT_HEADERS = [
@@ -197,8 +203,8 @@ export function formatIssueCreated(event: PluginEvent): SlackMessage {
   const statusKr = status ? (STATUS_KR[status] ?? status) : "";
 
   // Header line
-  let header = `${priorityEmoji} *새 이슈: ${identifier}*`;
-  if (parentIdentifier) header += ` (상위: ${parentIdentifier})`;
+  let header = `${priorityEmoji} *새 이슈: ${issueLink(identifier)}*`;
+  if (parentIdentifier) header += ` (상위: ${issueLink(parentIdentifier)})`;
   header += `\n*${title}*`;
 
   // Description (truncated)
@@ -229,7 +235,7 @@ export function formatIssueCreated(event: PluginEvent): SlackMessage {
   blocks.push(contextFooter(event.occurredAt));
 
   return {
-    text: `${priorityEmoji} 새 이슈: ${identifier} - ${title} → ${assigneeName ? slackMention(assigneeName) : "미할당"}`,
+    text: `${priorityEmoji} 새 이슈: ${issueLink(identifier)} - ${title} → ${assigneeName ? slackMention(assigneeName) : "미할당"}`,
     blocks,
   };
 }
@@ -244,7 +250,7 @@ export function formatIssueDone(event: PluginEvent): SlackMessage {
 
   const { summary, executionResult } = extractExecutionResult(description);
 
-  const lines = [`:white_check_mark: *${identifier} 완료*`, `*${title}*`];
+  const lines = [`:white_check_mark: *${issueLink(identifier)} 완료*`, `*${title}*`];
   if (summary) lines.push(summary.slice(0, 300));
   const meta: string[] = [];
   if (assigneeName) meta.push(`:bust_in_silhouette: ${slackMention(assigneeName)}`);
@@ -267,7 +273,7 @@ export function formatIssueDone(event: PluginEvent): SlackMessage {
   blocks.push(contextFooter(event.occurredAt));
 
   return {
-    text: `:white_check_mark: 완료: ${identifier} - ${title}`,
+    text: `:white_check_mark: 완료: ${issueLink(identifier)} - ${title}`,
     blocks,
   };
 }
@@ -286,7 +292,7 @@ export function formatIssueStatusChanged(event: PluginEvent): SlackMessage {
 
   const { summary, executionResult } = extractExecutionResult(description);
 
-  const lines = [`${statusEmoji} *${identifier}* → ${statusKr}`];
+  const lines = [`${statusEmoji} *${issueLink(identifier)}* → ${statusKr}`];
   if (title) lines.push(`*${title}*`);
   if (summary) lines.push(summary.slice(0, 300));
   const meta: string[] = [];
@@ -309,7 +315,7 @@ export function formatIssueStatusChanged(event: PluginEvent): SlackMessage {
   blocks.push(contextFooter(event.occurredAt));
 
   return {
-    text: `${statusEmoji} ${identifier} → ${statusKr}: ${title}`,
+    text: `${statusEmoji} ${issueLink(identifier)} → ${statusKr}: ${title}`,
     blocks,
   };
 }

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -202,20 +202,15 @@ export function formatIssueCreated(event: PluginEvent): SlackMessage {
   const priorityKr = priority ? (PRIORITY_KR[priority] ?? priority) : null;
   const statusKr = status ? (STATUS_KR[status] ?? status) : "";
 
-  // Header line
-  let header = `${priorityEmoji} *새 이슈: ${issueLink(identifier)}*`;
-  if (parentIdentifier) header += ` (상위: ${issueLink(parentIdentifier)})`;
-  header += `\n*${title}*`;
-
-  // Description (truncated)
+  const detailLines = [title ? `*${title}*` : issueLink(identifier)];
   if (description) {
-    header += `\n${description.slice(0, 300)}`;
+    detailLines.push(description.slice(0, 300));
   }
 
   const blocks: Array<Record<string, unknown>> = [
     {
       type: "section",
-      text: { type: "mrkdwn", text: header },
+      text: { type: "mrkdwn", text: detailLines.join("\n") },
       accessory: viewButton("대시보드", `${dashboardBase}/issues/${event.entityId}`),
     },
   ];
@@ -234,8 +229,12 @@ export function formatIssueCreated(event: PluginEvent): SlackMessage {
 
   blocks.push(contextFooter(event.occurredAt));
 
+  let text = `${priorityEmoji} 새 이슈: ${issueLink(identifier)}`;
+  if (parentIdentifier) text += ` (상위: ${issueLink(parentIdentifier)})`;
+  text += ` → ${assigneeName ? slackMention(assigneeName) : "미할당"}`;
+
   return {
-    text: `${priorityEmoji} 새 이슈: ${issueLink(identifier)} - ${title} → ${assigneeName ? slackMention(assigneeName) : "미할당"}`,
+    text,
     blocks,
   };
 }
@@ -250,17 +249,17 @@ export function formatIssueDone(event: PluginEvent): SlackMessage {
 
   const { summary, executionResult } = extractExecutionResult(description);
 
-  const lines = [`:white_check_mark: *${issueLink(identifier)} 완료*`, `*${title}*`];
-  if (summary) lines.push(summary.slice(0, 300));
+  const detailLines = [title ? `*${title}*` : issueLink(identifier)];
+  if (summary) detailLines.push(summary.slice(0, 300));
   const meta: string[] = [];
   if (assigneeName) meta.push(`:bust_in_silhouette: ${slackMention(assigneeName)}`);
   if (projectName) meta.push(`:file_folder: ${projectName}`);
-  if (meta.length > 0) lines.push(meta.join(" · "));
+  if (meta.length > 0) detailLines.push(meta.join(" · "));
 
   const blocks: Array<Record<string, unknown>> = [
     {
       type: "section",
-      text: { type: "mrkdwn", text: lines.join("\n") },
+      text: { type: "mrkdwn", text: detailLines.join("\n") },
       accessory: viewButton("대시보드", `${dashboardBase}/issues/${event.entityId}`),
     },
   ];
@@ -273,7 +272,7 @@ export function formatIssueDone(event: PluginEvent): SlackMessage {
   blocks.push(contextFooter(event.occurredAt));
 
   return {
-    text: `:white_check_mark: 완료: ${issueLink(identifier)} - ${title}`,
+    text: `:white_check_mark: 완료: ${issueLink(identifier)}`,
     blocks,
   };
 }
@@ -292,18 +291,22 @@ export function formatIssueStatusChanged(event: PluginEvent): SlackMessage {
 
   const { summary, executionResult } = extractExecutionResult(description);
 
-  const lines = [`${statusEmoji} *${issueLink(identifier)}* → ${statusKr}`];
-  if (title) lines.push(`*${title}*`);
-  if (summary) lines.push(summary.slice(0, 300));
+  const detailLines: string[] = [];
+  if (title) {
+    detailLines.push(`*${title}*`);
+  } else {
+    detailLines.push(issueLink(identifier));
+  }
+  if (summary) detailLines.push(summary.slice(0, 300));
   const meta: string[] = [];
   if (assigneeName) meta.push(`:bust_in_silhouette: ${slackMention(assigneeName)}`);
   if (projectName) meta.push(`:file_folder: ${projectName}`);
-  if (meta.length > 0) lines.push(meta.join(" · "));
+  if (meta.length > 0) detailLines.push(meta.join(" · "));
 
   const blocks: Array<Record<string, unknown>> = [
     {
       type: "section",
-      text: { type: "mrkdwn", text: lines.join("\n") },
+      text: { type: "mrkdwn", text: detailLines.join("\n") },
     },
   ];
 
@@ -315,7 +318,7 @@ export function formatIssueStatusChanged(event: PluginEvent): SlackMessage {
   blocks.push(contextFooter(event.occurredAt));
 
   return {
-    text: `${statusEmoji} ${issueLink(identifier)} → ${statusKr}: ${title}`,
+    text: `${statusEmoji} ${issueLink(identifier)} → ${statusKr}`,
     blocks,
   };
 }

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -57,6 +57,73 @@ function slackMention(name: string): string {
   return uid ? `<@${uid}>` : name;
 }
 
+// --- Execution result extraction ---
+
+const EXEC_RESULT_HEADERS = [
+  /^##\s*실행\s*결과/m,
+  /^##\s*Self-Verification/m,
+  /^##\s*판단/m,
+  /^##\s*Execution Result/mi,
+];
+
+/**
+ * Extract "실행 결과" / "Self-Verification" / "판단" sections from markdown description.
+ * Returns { summary, executionResult } where summary is the first ~300 chars before the result section,
+ * and executionResult is the full extracted section(s).
+ */
+export function extractExecutionResult(description: string | null): {
+  summary: string;
+  executionResult: string | null;
+} {
+  if (!description) return { summary: "", executionResult: null };
+
+  // Find the earliest matching header
+  let earliestIdx = -1;
+  for (const re of EXEC_RESULT_HEADERS) {
+    const match = re.exec(description);
+    if (match && (earliestIdx === -1 || match.index < earliestIdx)) {
+      earliestIdx = match.index;
+    }
+  }
+
+  if (earliestIdx === -1) {
+    // No execution result section found — return truncated summary
+    return { summary: description.slice(0, 300), executionResult: null };
+  }
+
+  const summary = description.slice(0, Math.min(earliestIdx, 300)).trim();
+  const executionResult = description.slice(earliestIdx).trim();
+  return { summary, executionResult };
+}
+
+/**
+ * Format execution result as Slack blocks (mrkdwn sections, max 3000 chars per block).
+ */
+export function formatExecutionResultBlocks(executionResult: string): Array<Record<string, unknown>> {
+  const blocks: Array<Record<string, unknown>> = [];
+  // Slack section text limit is 3000 chars
+  const MAX_BLOCK_LEN = 2900;
+  let remaining = executionResult;
+
+  // Add a divider before execution results
+  blocks.push({ type: "divider" });
+  blocks.push({
+    type: "context",
+    elements: [{ type: "mrkdwn", text: ":brain: *에이전트 실행 결과*" }],
+  });
+
+  while (remaining.length > 0) {
+    const chunk = remaining.slice(0, MAX_BLOCK_LEN);
+    remaining = remaining.slice(MAX_BLOCK_LEN);
+    blocks.push({
+      type: "section",
+      text: { type: "mrkdwn", text: chunk },
+    });
+  }
+
+  return blocks;
+}
+
 function contextFooter(timestamp?: string): Record<string, unknown> {
   const elements: Array<Record<string, unknown>> = [
     { type: "mrkdwn", text: ":paperclip: *Paperclip*" },
@@ -175,8 +242,10 @@ export function formatIssueDone(event: PluginEvent): SlackMessage {
   const assigneeName = p.assigneeName ? String(p.assigneeName) : null;
   const projectName = p.projectName ? String(p.projectName) : null;
 
+  const { summary, executionResult } = extractExecutionResult(description);
+
   const lines = [`:white_check_mark: *${identifier} 완료*`, `*${title}*`];
-  if (description) lines.push(description.slice(0, 150));
+  if (summary) lines.push(summary.slice(0, 300));
   const meta: string[] = [];
   if (assigneeName) meta.push(`:bust_in_silhouette: ${slackMention(assigneeName)}`);
   if (projectName) meta.push(`:file_folder: ${projectName}`);
@@ -188,8 +257,14 @@ export function formatIssueDone(event: PluginEvent): SlackMessage {
       text: { type: "mrkdwn", text: lines.join("\n") },
       accessory: viewButton("대시보드", `${dashboardBase}/issues/${event.entityId}`),
     },
-    contextFooter(event.occurredAt),
   ];
+
+  // Append execution result blocks if present
+  if (executionResult) {
+    blocks.push(...formatExecutionResultBlocks(executionResult));
+  }
+
+  blocks.push(contextFooter(event.occurredAt));
 
   return {
     text: `:white_check_mark: 완료: ${identifier} - ${title}`,
@@ -209,9 +284,11 @@ export function formatIssueStatusChanged(event: PluginEvent): SlackMessage {
   const statusEmoji = STATUS_EMOJI[status] ?? ":hammer_and_wrench:";
   const statusKr = STATUS_KR[status] ?? status;
 
+  const { summary, executionResult } = extractExecutionResult(description);
+
   const lines = [`${statusEmoji} *${identifier}* → ${statusKr}`];
   if (title) lines.push(`*${title}*`);
-  if (description) lines.push(description.slice(0, 150));
+  if (summary) lines.push(summary.slice(0, 300));
   const meta: string[] = [];
   if (assigneeName) meta.push(`:bust_in_silhouette: ${slackMention(assigneeName)}`);
   if (projectName) meta.push(`:file_folder: ${projectName}`);
@@ -222,8 +299,14 @@ export function formatIssueStatusChanged(event: PluginEvent): SlackMessage {
       type: "section",
       text: { type: "mrkdwn", text: lines.join("\n") },
     },
-    contextFooter(event.occurredAt),
   ];
+
+  // Append execution result blocks if present
+  if (executionResult) {
+    blocks.push(...formatExecutionResultBlocks(executionResult));
+  }
+
+  blocks.push(contextFooter(event.occurredAt));
 
   return {
     text: `${statusEmoji} ${identifier} → ${statusKr}: ${title}`,
@@ -608,6 +691,106 @@ export function formatEscalationResolved(
           text: `${emoji} *에스컬레이션 ${label}* — <@${userId}>`,
         },
       },
+    ],
+  };
+}
+
+// --- Goal / Project / Comment / Run formatters ---
+
+export function formatGoalCreated(event: PluginEvent): SlackMessage {
+  const p = event.payload as Payload;
+  const title = String(p.title ?? "Untitled");
+  const description = p.description ? String(p.description).slice(0, 300) : "";
+
+  const blocks: Array<Record<string, unknown>> = [
+    {
+      type: "section",
+      text: { type: "mrkdwn", text: `:dart: *새 목표: ${title}*${description ? `\n${description}` : ""}` },
+      accessory: viewButton("대시보드", `${dashboardBase}/goals/${event.entityId}`),
+    },
+    contextFooter(event.occurredAt),
+  ];
+
+  return { text: `:dart: 새 목표: ${title}`, blocks };
+}
+
+export function formatGoalUpdated(event: PluginEvent): SlackMessage {
+  const p = event.payload as Payload;
+  const title = String(p.title ?? "");
+  const status = p.status ? String(p.status) : null;
+  const statusEmoji = status ? (STATUS_EMOJI[status] ?? ":arrows_counterclockwise:") : ":arrows_counterclockwise:";
+  const statusKr = status ? (STATUS_KR[status] ?? status) : "업데이트";
+
+  return {
+    text: `${statusEmoji} 목표 업데이트: ${title} → ${statusKr}`,
+    blocks: [
+      { type: "section", text: { type: "mrkdwn", text: `${statusEmoji} *목표 업데이트* → ${statusKr}\n${title}` } },
+    ],
+  };
+}
+
+export function formatProjectCreated(event: PluginEvent): SlackMessage {
+  const p = event.payload as Payload;
+  const title = String(p.title ?? p.name ?? "Untitled");
+
+  return {
+    text: `:file_folder: 프로젝트 생성: ${title}`,
+    blocks: [
+      { type: "section", text: { type: "mrkdwn", text: `:file_folder: *프로젝트 생성:* ${title}` } },
+    ],
+  };
+}
+
+export function formatProjectUpdated(event: PluginEvent): SlackMessage {
+  const p = event.payload as Payload;
+  const title = String(p.title ?? p.name ?? "");
+
+  return {
+    text: `:file_folder: 프로젝트 업데이트: ${title}`,
+    blocks: [
+      { type: "section", text: { type: "mrkdwn", text: `:file_folder: *프로젝트 업데이트:* ${title}` } },
+    ],
+  };
+}
+
+export function formatCommentCreated(event: PluginEvent): SlackMessage {
+  const p = event.payload as Payload;
+  const body = p.body ? String(p.body).slice(0, 500) : "";
+  const authorName = p.authorName ? String(p.authorName) : (p.agentName ? String(p.agentName) : "");
+  const identifier = p.issueIdentifier ? String(p.issueIdentifier) : "";
+  const author = authorName ? slackMention(authorName) : event.actorId;
+
+  return {
+    text: `💬 ${author}: ${body.slice(0, 100)}`,
+    blocks: [
+      { type: "section", text: { type: "mrkdwn", text: `:speech_balloon: ${author}${identifier ? ` (${identifier})` : ""}\n${body}` } },
+    ],
+  };
+}
+
+export function formatAgentRunStarted(event: PluginEvent): SlackMessage {
+  const p = event.payload as Payload;
+  const agentName = p.agentName ? String(p.agentName) : (p.name ? String(p.name) : "에이전트");
+  const issueTitle = p.issueTitle ? String(p.issueTitle) : "";
+
+  return {
+    text: `⚡ ${agentName} 착수${issueTitle ? `: ${issueTitle}` : ""}`,
+    blocks: [
+      { type: "section", text: { type: "mrkdwn", text: `:zap: ${slackMention(agentName)} *착수*${issueTitle ? ` — ${issueTitle}` : ""}` } },
+    ],
+  };
+}
+
+export function formatApprovalDecided(event: PluginEvent): SlackMessage {
+  const p = event.payload as Payload;
+  const decision = String(p.decision ?? p.status ?? "decided");
+  const emoji = decision === "approved" ? ":white_check_mark:" : ":x:";
+  const label = decision === "approved" ? "승인" : "거부";
+
+  return {
+    text: `${emoji} 승인 ${label}`,
+    blocks: [
+      { type: "section", text: { type: "mrkdwn", text: `${emoji} *승인 ${label}*` } },
     ],
   };
 }

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -753,34 +753,6 @@ export function formatProjectUpdated(event: PluginEvent): SlackMessage {
   };
 }
 
-export function formatCommentCreated(event: PluginEvent): SlackMessage {
-  const p = event.payload as Payload;
-  const body = p.body ? String(p.body).slice(0, 500) : "";
-  const authorName = p.authorName ? String(p.authorName) : (p.agentName ? String(p.agentName) : "");
-  const identifier = p.issueIdentifier ? String(p.issueIdentifier) : "";
-  const author = authorName ? slackMention(authorName) : event.actorId;
-
-  return {
-    text: `💬 ${author}: ${body.slice(0, 100)}`,
-    blocks: [
-      { type: "section", text: { type: "mrkdwn", text: `:speech_balloon: ${author}${identifier ? ` (${identifier})` : ""}\n${body}` } },
-    ],
-  };
-}
-
-export function formatAgentRunStarted(event: PluginEvent): SlackMessage {
-  const p = event.payload as Payload;
-  const agentName = p.agentName ? String(p.agentName) : (p.name ? String(p.name) : "에이전트");
-  const issueTitle = p.issueTitle ? String(p.issueTitle) : "";
-
-  return {
-    text: `⚡ ${agentName} 착수${issueTitle ? `: ${issueTitle}` : ""}`,
-    blocks: [
-      { type: "section", text: { type: "mrkdwn", text: `:zap: ${slackMention(agentName)} *착수*${issueTitle ? ` — ${issueTitle}` : ""}` } },
-    ],
-  };
-}
-
 export function formatApprovalDecided(event: PluginEvent): SlackMessage {
   const p = event.payload as Payload;
   const decision = String(p.decision ?? p.status ?? "decided");

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -10,12 +10,45 @@ export function setBaseUrl(url: string) {
   dashboardBase = url.replace(/\/+$/, "");
 }
 
+// --- Priority emoji mapping ---
+const PRIORITY_EMOJI: Record<string, string> = {
+  critical: ":rotating_light:",
+  high: ":red_circle:",
+  medium: ":large_orange_circle:",
+  low: ":white_circle:",
+};
+
+const PRIORITY_KR: Record<string, string> = {
+  critical: "긴급",
+  high: "높음",
+  medium: "보통",
+  low: "낮음",
+};
+
+const STATUS_EMOJI: Record<string, string> = {
+  backlog: ":inbox_tray:",
+  todo: ":clipboard:",
+  in_progress: ":hammer_and_wrench:",
+  in_review: ":mag:",
+  done: ":white_check_mark:",
+  cancelled: ":no_entry_sign:",
+};
+
+const STATUS_KR: Record<string, string> = {
+  backlog: "대기",
+  todo: "할 일",
+  in_progress: "진행 중",
+  in_review: "검토 중",
+  done: "완료",
+  cancelled: "취소",
+};
+
 function contextFooter(timestamp?: string): Record<string, unknown> {
   const elements: Array<Record<string, unknown>> = [
-    { type: "mrkdwn", text: "Paperclip" },
+    { type: "mrkdwn", text: ":paperclip: *Paperclip*" },
   ];
   if (timestamp) {
-    elements.push({ type: "mrkdwn", text: `<!date^${Math.floor(new Date(timestamp).getTime() / 1000)}^{date_short_pretty} at {time}|${timestamp}>` });
+    elements.push({ type: "mrkdwn", text: `<!date^${Math.floor(new Date(timestamp).getTime() / 1000)}^{date_short_pretty} {time}|${timestamp}>` });
   }
   return { type: "context", elements };
 }
@@ -70,30 +103,43 @@ export function formatIssueCreated(event: PluginEvent): SlackMessage {
   const p = event.payload as Payload;
   const identifier = String(p.identifier ?? event.entityId);
   const title = String(p.title ?? "Untitled");
-  const description = p.description ? String(p.description).slice(0, 300) : null;
+  const description = p.description ? String(p.description) : null;
   const status = p.status ? String(p.status) : null;
   const priority = p.priority ? String(p.priority) : null;
   const assigneeName = p.assigneeName ? String(p.assigneeName) : null;
   const projectName = p.projectName ? String(p.projectName) : null;
+  const goalName = p.goalName ? String(p.goalName) : null;
+  const parentIdentifier = p.parentIdentifier ? String(p.parentIdentifier) : null;
 
-  const fields: Array<{ type: string; text: string }> = [];
-  if (status) fields.push({ type: "mrkdwn", text: `*Status*\n\`${status}\`` });
-  if (priority) fields.push({ type: "mrkdwn", text: `*Priority*\n\`${priority}\`` });
-  if (assigneeName) fields.push({ type: "mrkdwn", text: `*Assignee*\n${assigneeName}` });
-  if (projectName) fields.push({ type: "mrkdwn", text: `*Project*\n${projectName}` });
+  const priorityEmoji = priority ? (PRIORITY_EMOJI[priority] ?? ":red_circle:") : ":red_circle:";
+  const priorityKr = priority ? (PRIORITY_KR[priority] ?? priority) : null;
+  const statusKr = status ? (STATUS_KR[status] ?? status) : "";
+
+  // Header line
+  let header = `${priorityEmoji} *새 이슈: ${identifier}*`;
+  if (parentIdentifier) header += ` (상위: ${parentIdentifier})`;
+  header += `\n*${title}*`;
+
+  // Description (truncated)
+  if (description) {
+    header += `\n${description.slice(0, 300)}`;
+  }
 
   const blocks: Array<Record<string, unknown>> = [
     {
       type: "section",
-      text: {
-        type: "mrkdwn",
-        text: description
-          ? `*New issue created*\n*${identifier}* ${title}\n> ${description}`
-          : `*New issue created*\n*${identifier}* ${title}`,
-      },
-      accessory: viewButton("View Issue", `${dashboardBase}/issues/${event.entityId}`),
+      text: { type: "mrkdwn", text: header },
+      accessory: viewButton("대시보드", `${dashboardBase}/issues/${event.entityId}`),
     },
   ];
+
+  // Fields block for metadata
+  const fields: Array<{ type: string; text: string }> = [];
+  fields.push({ type: "mrkdwn", text: `*담당자*\n:bust_in_silhouette: ${assigneeName ?? "미할당"}` });
+  if (priorityKr) fields.push({ type: "mrkdwn", text: `*우선순위*\n${priorityEmoji} ${priorityKr}` });
+  if (projectName) fields.push({ type: "mrkdwn", text: `*프로젝트*\n:file_folder: ${projectName}` });
+  if (goalName) fields.push({ type: "mrkdwn", text: `*목표*\n:dart: ${goalName}` });
+  if (statusKr) fields.push({ type: "mrkdwn", text: `*상태*\n:clipboard: ${statusKr}` });
 
   if (fields.length > 0) {
     blocks.push({ type: "section", fields });
@@ -102,7 +148,7 @@ export function formatIssueCreated(event: PluginEvent): SlackMessage {
   blocks.push(contextFooter(event.occurredAt));
 
   return {
-    text: `New issue: ${identifier} - ${title}`,
+    text: `${priorityEmoji} 새 이슈: ${identifier} - ${title} → ${assigneeName ?? "미할당"}`,
     blocks,
   };
 }
@@ -111,30 +157,62 @@ export function formatIssueDone(event: PluginEvent): SlackMessage {
   const p = event.payload as Payload;
   const identifier = String(p.identifier ?? event.entityId);
   const title = String(p.title ?? "");
+  const description = p.description ? String(p.description) : null;
+  const assigneeName = p.assigneeName ? String(p.assigneeName) : null;
+  const projectName = p.projectName ? String(p.projectName) : null;
 
-  const fields: Array<{ type: string; text: string }> = [];
-  if (p.status) fields.push({ type: "mrkdwn", text: `*Status*\n\`${String(p.status)}\`` });
-  if (p.priority) fields.push({ type: "mrkdwn", text: `*Priority*\n\`${String(p.priority)}\`` });
+  const lines = [`:white_check_mark: *${identifier} 완료*`, `*${title}*`];
+  if (description) lines.push(description.slice(0, 150));
+  const meta: string[] = [];
+  if (assigneeName) meta.push(`:bust_in_silhouette: ${assigneeName}`);
+  if (projectName) meta.push(`:file_folder: ${projectName}`);
+  if (meta.length > 0) lines.push(meta.join(" · "));
 
   const blocks: Array<Record<string, unknown>> = [
     {
       type: "section",
-      text: {
-        type: "mrkdwn",
-        text: `*Issue completed* :white_check_mark:\n*${identifier}* ${title} is now done.`,
-      },
-      accessory: viewButton("View Issue", `${dashboardBase}/issues/${event.entityId}`),
+      text: { type: "mrkdwn", text: lines.join("\n") },
+      accessory: viewButton("대시보드", `${dashboardBase}/issues/${event.entityId}`),
     },
+    contextFooter(event.occurredAt),
   ];
 
-  if (fields.length > 0) {
-    blocks.push({ type: "section", fields });
-  }
+  return {
+    text: `:white_check_mark: 완료: ${identifier} - ${title}`,
+    blocks,
+  };
+}
 
-  blocks.push(contextFooter(event.occurredAt));
+export function formatIssueStatusChanged(event: PluginEvent): SlackMessage {
+  const p = event.payload as Payload;
+  const identifier = String(p.identifier ?? event.entityId);
+  const title = String(p.title ?? "");
+  const description = p.description ? String(p.description) : null;
+  const status = p.status ? String(p.status) : "unknown";
+  const assigneeName = p.assigneeName ? String(p.assigneeName) : null;
+  const projectName = p.projectName ? String(p.projectName) : null;
+
+  const statusEmoji = STATUS_EMOJI[status] ?? ":hammer_and_wrench:";
+  const statusKr = STATUS_KR[status] ?? status;
+
+  const lines = [`${statusEmoji} *${identifier}* → ${statusKr}`];
+  if (title) lines.push(`*${title}*`);
+  if (description) lines.push(description.slice(0, 150));
+  const meta: string[] = [];
+  if (assigneeName) meta.push(`:bust_in_silhouette: ${assigneeName}`);
+  if (projectName) meta.push(`:file_folder: ${projectName}`);
+  if (meta.length > 0) lines.push(meta.join(" · "));
+
+  const blocks: Array<Record<string, unknown>> = [
+    {
+      type: "section",
+      text: { type: "mrkdwn", text: lines.join("\n") },
+    },
+    contextFooter(event.occurredAt),
+  ];
 
   return {
-    text: `Issue done: ${identifier}`,
+    text: `${statusEmoji} ${identifier} → ${statusKr}: ${title}`,
     blocks,
   };
 }
@@ -149,10 +227,10 @@ export function formatApprovalCreated(event: PluginEvent): SlackMessage {
   const issueIds = Array.isArray(p.issueIds) ? p.issueIds : [];
 
   const fields: Array<{ type: string; text: string }> = [];
-  if (agentName) fields.push({ type: "mrkdwn", text: `*Agent*\n${agentName}` });
-  fields.push({ type: "mrkdwn", text: `*Type*\n\`${approvalType}\`` });
+  if (agentName) fields.push({ type: "mrkdwn", text: `*요청 에이전트*\n:robot_face: ${agentName}` });
+  fields.push({ type: "mrkdwn", text: `*유형*\n\`${approvalType}\`` });
   if (issueIds.length > 0) {
-    fields.push({ type: "mrkdwn", text: `*Linked Issues*\n${issueIds.join(", ")}` });
+    fields.push({ type: "mrkdwn", text: `*관련 이슈*\n${issueIds.join(", ")}` });
   }
 
   const blocks: Array<Record<string, unknown>> = [
@@ -161,8 +239,8 @@ export function formatApprovalCreated(event: PluginEvent): SlackMessage {
       text: {
         type: "mrkdwn",
         text: description
-          ? `*Approval requested* :rotating_light:\n${title ? `*${title}*\n` : ""}${description}`
-          : `*Approval requested* :rotating_light:${title ? `\n*${title}*` : ""}`,
+          ? `:rotating_light: *승인 요청*\n${title ? `*${title}*\n` : ""}${description}`
+          : `:rotating_light: *승인 요청*${title ? `\n*${title}*` : ""}`,
       },
     },
   ];
@@ -176,21 +254,21 @@ export function formatApprovalCreated(event: PluginEvent): SlackMessage {
     elements: [
       {
         type: "button",
-        text: { type: "plain_text", text: "Approve" },
+        text: { type: "plain_text", text: "승인" },
         style: "primary",
         action_id: "approval_approve",
         value: approvalId,
       },
       {
         type: "button",
-        text: { type: "plain_text", text: "Reject" },
+        text: { type: "plain_text", text: "거부" },
         style: "danger",
         action_id: "approval_reject",
         value: approvalId,
       },
       {
         type: "button",
-        text: { type: "plain_text", text: "View" },
+        text: { type: "plain_text", text: "상세 보기" },
         url: `${dashboardBase}/approvals/${approvalId}`,
         action_id: "approval_view",
       },
@@ -200,7 +278,7 @@ export function formatApprovalCreated(event: PluginEvent): SlackMessage {
   blocks.push(contextFooter(event.occurredAt));
 
   return {
-    text: `Approval needed (${approvalType}) for ${issueIds.length} issue(s)`,
+    text: `:rotating_light: 승인 필요 (${approvalType}) — ${issueIds.length}건`,
     blocks,
   };
 }
@@ -210,7 +288,7 @@ export function formatApprovalResolved(
   approved: boolean,
   userId: string,
 ): SlackMessage {
-  const action = approved ? "Approved" : "Rejected";
+  const action = approved ? "승인됨" : "거부됨";
   const emoji = approved ? ":white_check_mark:" : ":x:";
 
   return {
@@ -220,9 +298,9 @@ export function formatApprovalResolved(
         type: "section",
         text: {
           type: "mrkdwn",
-          text: `${emoji} *${action}* by <@${userId}>`,
+          text: `${emoji} *${action}* — <@${userId}>`,
         },
-        accessory: viewButton("View", `${dashboardBase}/approvals/${approvalId}`),
+        accessory: viewButton("보기", `${dashboardBase}/approvals/${approvalId}`),
       },
     ],
   };
@@ -234,13 +312,13 @@ export function formatAgentError(event: PluginEvent): SlackMessage {
   const errorMessage = String(p.error ?? p.message ?? "Unknown error");
 
   return {
-    text: `Agent error: ${agentName}`,
+    text: `:warning: 에이전트 에러: ${agentName}`,
     blocks: [
       {
         type: "section",
         text: {
           type: "mrkdwn",
-          text: `*Agent error* :warning:\n*${agentName}* encountered an error:\n\`\`\`${errorMessage.slice(0, 500)}\`\`\``,
+          text: `:warning: *에이전트 에러*\n:robot_face: *${agentName}*\n\`\`\`${errorMessage.slice(0, 500)}\`\`\``,
         },
       },
       contextFooter(event.occurredAt),
@@ -253,13 +331,13 @@ export function formatAgentConnected(event: PluginEvent): SlackMessage {
   const agentName = String(p.agentName ?? p.name ?? event.entityId);
 
   return {
-    text: `Agent online: ${agentName}`,
+    text: `:white_check_mark: 에이전트 온라인: ${agentName}`,
     blocks: [
       {
         type: "section",
         text: {
           type: "mrkdwn",
-          text: `*Agent online* :white_check_mark:\n*${agentName}* is now connected and ready.`,
+          text: `:white_check_mark: *에이전트 온라인*\n:robot_face: *${agentName}* 연결됨`,
         },
       },
       contextFooter(event.occurredAt),
@@ -275,13 +353,13 @@ export function formatBudgetThreshold(event: PluginEvent): SlackMessage {
   const pct = p.percentUsed != null ? String(p.percentUsed) : "?";
 
   return {
-    text: `Budget alert: ${agentName} at ${pct}%`,
+    text: `:chart_with_upwards_trend: 예산 알림: ${agentName} ${pct}% 사용`,
     blocks: [
       {
         type: "section",
         text: {
           type: "mrkdwn",
-          text: `*Budget threshold reached* :chart_with_upwards_trend:\n*${agentName}* has used *${pct}%* of budget ($${spent} / $${budget})`,
+          text: `:chart_with_upwards_trend: *예산 임계값 도달*\n:robot_face: *${agentName}* — *${pct}%* 사용 ($${spent} / $${budget})`,
         },
       },
       contextFooter(event.occurredAt),
@@ -295,13 +373,13 @@ export function formatOnboardingMilestone(event: PluginEvent): SlackMessage {
   const milestone = String(p.milestone ?? "first heartbeat");
 
   return {
-    text: `Milestone: ${agentName} - ${milestone}`,
+    text: `:tada: 마일스톤: ${agentName} — ${milestone}`,
     blocks: [
       {
         type: "section",
         text: {
           type: "mrkdwn",
-          text: `*Onboarding milestone* :tada:\n*${agentName}* achieved: ${milestone}`,
+          text: `:tada: *마일스톤 달성*\n:robot_face: *${agentName}* — ${milestone}`,
         },
       },
       contextFooter(event.occurredAt),
@@ -317,19 +395,20 @@ export function formatDailyDigest(stats: {
   topAgent: string;
 }): SlackMessage {
   return {
-    text: `Daily digest: ${stats.tasksCompleted} tasks completed, $${stats.totalCost} spent`,
+    text: `팀 활동 요약: ${stats.tasksCompleted}건 완료, $${stats.totalCost} 사용`,
     blocks: [
       {
         type: "header",
-        text: { type: "plain_text", text: "Daily Activity Digest" },
+        text: { type: "plain_text", text: ":bar_chart: 팀 활동 요약" },
       },
+      { type: "divider" },
       {
         type: "section",
         fields: [
-          { type: "mrkdwn", text: `*Tasks completed*\n${stats.tasksCompleted}` },
-          { type: "mrkdwn", text: `*Tasks created*\n${stats.tasksCreated}` },
-          { type: "mrkdwn", text: `*Active agents*\n${stats.agentsActive}` },
-          { type: "mrkdwn", text: `*Total cost*\n$${stats.totalCost}` },
+          { type: "mrkdwn", text: `*:white_check_mark: 완료*\n${stats.tasksCompleted}건` },
+          { type: "mrkdwn", text: `*:inbox_tray: 생성*\n${stats.tasksCreated}건` },
+          { type: "mrkdwn", text: `*:robot_face: 활성 에이전트*\n${stats.agentsActive}명` },
+          { type: "mrkdwn", text: `*:moneybag: 비용*\n$${stats.totalCost}` },
         ],
       },
       ...(stats.topAgent
@@ -338,7 +417,7 @@ export function formatDailyDigest(stats: {
               type: "section" as const,
               text: {
                 type: "mrkdwn" as const,
-                text: `*Top performer:* ${stats.topAgent}`,
+                text: `:trophy: *MVP:* ${stats.topAgent}`,
               },
             },
           ]
@@ -346,7 +425,7 @@ export function formatDailyDigest(stats: {
       { type: "divider" },
       {
         type: "context",
-        elements: [{ type: "mrkdwn", text: "Paperclip - Daily Digest" }],
+        elements: [{ type: "mrkdwn", text: ":paperclip: *Paperclip* — 2시간 활동 요약" }],
       },
     ],
   };
@@ -359,26 +438,26 @@ export function formatEscalationMessage(escalation: EscalationRecord): SlackMess
 
   blocks.push({
     type: "header",
-    text: { type: "plain_text", text: `Escalation from ${escalation.agentName ?? "Agent"}` },
+    text: { type: "plain_text", text: `:sos: ${escalation.agentName ?? "에이전트"} 에스컬레이션` },
   });
 
   const fields: Array<{ type: string; text: string }> = [
-    { type: "mrkdwn", text: `*Reason*\n${escalation.reason}` },
+    { type: "mrkdwn", text: `*사유*\n${escalation.reason}` },
   ];
   if (escalation.confidence != null) {
-    fields.push({ type: "mrkdwn", text: `*Confidence*\n${escalation.confidence}` });
+    fields.push({ type: "mrkdwn", text: `*확신도*\n${escalation.confidence}` });
   }
   blocks.push({ type: "section", fields });
 
   if (escalation.conversationHistory && escalation.conversationHistory.length > 0) {
     const lastMessages = escalation.conversationHistory.slice(-5);
     const historyText = lastMessages
-      .map((msg) => `${msg.role}: ${msg.text}`)
+      .map((msg) => `*${msg.role}:* ${msg.text}`)
       .join("\n");
     blocks.push({
       type: "context",
       elements: [
-        { type: "mrkdwn", text: `*Recent conversation*\n${historyText.slice(0, 2000)}` },
+        { type: "mrkdwn", text: `*최근 대화*\n${historyText.slice(0, 2000)}` },
       ],
     });
   }
@@ -388,7 +467,7 @@ export function formatEscalationMessage(escalation: EscalationRecord): SlackMess
       type: "section",
       text: {
         type: "mrkdwn",
-        text: `*Agent reasoning*\n${escalation.agentReasoning}`,
+        text: `*에이전트 판단*\n${escalation.agentReasoning}`,
       },
     });
   }
@@ -398,7 +477,7 @@ export function formatEscalationMessage(escalation: EscalationRecord): SlackMess
       type: "section",
       text: {
         type: "mrkdwn",
-        text: `*Suggested reply*\n> ${escalation.suggestedReply}`,
+        text: `*제안 답변*\n> ${escalation.suggestedReply}`,
       },
     });
   }
@@ -408,26 +487,26 @@ export function formatEscalationMessage(escalation: EscalationRecord): SlackMess
     elements: [
       {
         type: "button",
-        text: { type: "plain_text", text: "Use Suggested Reply" },
+        text: { type: "plain_text", text: "제안 답변 사용" },
         style: "primary",
         action_id: "escalation_use_suggested",
         value: escalation.id,
       },
       {
         type: "button",
-        text: { type: "plain_text", text: "Reply to Customer" },
+        text: { type: "plain_text", text: "직접 답변" },
         action_id: "escalation_reply",
         value: escalation.id,
       },
       {
         type: "button",
-        text: { type: "plain_text", text: "Override Agent" },
+        text: { type: "plain_text", text: "에이전트 오버라이드" },
         action_id: "escalation_override",
         value: escalation.id,
       },
       {
         type: "button",
-        text: { type: "plain_text", text: "Dismiss" },
+        text: { type: "plain_text", text: "무시" },
         style: "danger",
         action_id: "escalation_dismiss",
         value: escalation.id,
@@ -436,7 +515,7 @@ export function formatEscalationMessage(escalation: EscalationRecord): SlackMess
   });
 
   return {
-    text: `Escalation from ${escalation.agentName ?? "Agent"}: ${escalation.reason}`,
+    text: `:sos: ${escalation.agentName ?? "에이전트"} 에스컬레이션: ${escalation.reason}`,
     blocks,
   };
 }
@@ -448,21 +527,21 @@ export function formatEscalationResolved(
 ): SlackMessage {
   const emoji = action === "dismiss" || action === "escalation_dismiss" ? ":x:" : ":white_check_mark:";
   const label = action === "escalation_use_suggested"
-    ? "Used suggested reply"
+    ? "제안 답변 사용"
     : action === "escalation_override"
-      ? "Overrode agent"
+      ? "에이전트 오버라이드"
       : action === "escalation_dismiss"
-        ? "Dismissed"
-        : "Replied";
+        ? "무시됨"
+        : "답변 완료";
 
   return {
-    text: `Escalation ${label} by ${userId}`,
+    text: `에스컬레이션 ${label} — ${userId}`,
     blocks: [
       {
         type: "section",
         text: {
           type: "mrkdwn",
-          text: `${emoji} *Escalation ${label}* by <@${userId}>`,
+          text: `${emoji} *에스컬레이션 ${label}* — <@${userId}>`,
         },
       },
     ],

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -37,7 +37,7 @@ const manifest: PaperclipPluginManifestV1 = {
     "activity.log.write",
     "metrics.write",
     "jobs.schedule",
-    "agent.tools.register",
+    "agent.tools.register","projects.read","goals.read",
   ],
   entrypoints: {
     worker: "./dist/worker.js",
@@ -156,7 +156,7 @@ const manifest: PaperclipPluginManifestV1 = {
       jobKey: "daily-digest",
       displayName: "Daily Activity Digest",
       description: "Posts a summary of agent activity, costs, and completed tasks to Slack.",
-      schedule: "0 9 * * *",
+      schedule: "0 */2 * * *",
     },
     {
       jobKey: "check-escalation-timeouts",

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -724,9 +724,9 @@ const plugin = definePlugin({
     // Notification helper (supports per-type channel override + threading)
     // =========================================================================
 
-    // Dedup: skip events already processed (prevents double-posting)
+    // Dedup: content-based — same entity+type+status within TTL is duplicate
     const recentEvents = new Set<string>();
-    const DEDUP_TTL_MS = 30_000;
+    const DEDUP_TTL_MS = 10_000;
 
     const notify = async (
       event: PluginEvent,
@@ -734,10 +734,14 @@ const plugin = definePlugin({
       overrideChannelId?: string,
       opts?: { threadTs?: string },
     ) => {
-      // Dedup guard — skip if same eventId already processed
-      const dedupKey = `${event.eventId}:${event.eventType}`;
+      // Content-based dedup — same entity + event type + status = duplicate
+      const payload = event.payload as Record<string, unknown>;
+      const status = payload.status ? String(payload.status) : "";
+      const dedupKey = `${event.entityId}:${event.eventType}:${status}`;
       if (recentEvents.has(dedupKey)) {
-        ctx.logger.debug("Skipping duplicate event", { eventId: event.eventId, eventType: event.eventType });
+        ctx.logger.debug("Skipping duplicate event (content-dedup)", {
+          entityId: event.entityId, eventType: event.eventType, status,
+        });
         return;
       }
       recentEvents.add(dedupKey);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -36,6 +36,15 @@ import {
   formatDailyDigest,
   formatEscalationMessage,
   formatEscalationResolved,
+  extractExecutionResult,
+  formatExecutionResultBlocks,
+  formatGoalCreated,
+  formatGoalUpdated,
+  formatProjectCreated,
+  formatProjectUpdated,
+  formatCommentCreated,
+  formatAgentRunStarted,
+  formatApprovalDecided,
 } from "./formatters.js";
 import { processMediaFile, isMediaFile } from "./media-pipeline.js";
 import {
@@ -785,6 +794,7 @@ const plugin = definePlugin({
     }
 
     // issue.updated — all status changes go to the same thread as issue.created
+    // Enhanced: also sends execution result as a separate thread reply when present
     ctx.events.on("issue.updated", async (event: PluginEvent) => {
       const payload = event.payload as Record<string, unknown>;
       const status = payload.status ? String(payload.status) : null;
@@ -801,9 +811,39 @@ const plugin = definePlugin({
       ctx.logger.info("issue.updated thread lookup", { entityId: event.entityId, stateKey, threadTs, status });
 
       if (status === "done" && config.notifyOnIssueDone) {
-        await notify(event, formatIssueDone, undefined, threadTs ? { threadTs } : undefined);
+        const result = await notify(event, formatIssueDone, undefined, threadTs ? { threadTs } : undefined);
+        // Post execution result as a separate reply if it exceeds Slack block limits
+        const description = payload.description ? String(payload.description) : null;
+        const { executionResult } = extractExecutionResult(description);
+        if (executionResult && executionResult.length > 2900 && threadTs) {
+          const fallback = config.defaultChannelId;
+          const channelId = await resolveChannel(ctx, event.companyId, fallback);
+          if (channelId) {
+            const resultBlocks = formatExecutionResultBlocks(executionResult);
+            await postMessage(ctx, token, channelId, {
+              text: `실행 결과 (${String(payload.identifier ?? event.entityId)})`,
+              blocks: resultBlocks,
+            }, { threadTs });
+          }
+        }
       } else if (status !== "done" && (config as Record<string, unknown>).notifyOnIssueUpdated !== false) {
         await notify(event, formatIssueStatusChanged, undefined, threadTs ? { threadTs } : undefined);
+        // For in_review with execution results, also post a separate reply
+        if (status === "in_review" && threadTs) {
+          const description = payload.description ? String(payload.description) : null;
+          const { executionResult } = extractExecutionResult(description);
+          if (executionResult) {
+            const fallback = config.defaultChannelId;
+            const channelId = await resolveChannel(ctx, event.companyId, fallback);
+            if (channelId) {
+              const resultBlocks = formatExecutionResultBlocks(executionResult);
+              await postMessage(ctx, token, channelId, {
+                text: `실행 결과 (${String(payload.identifier ?? event.entityId)})`,
+                blocks: resultBlocks,
+              }, { threadTs });
+            }
+          }
+        }
       }
     });
 
@@ -815,7 +855,21 @@ const plugin = definePlugin({
 
     if (config.notifyOnAgentError) {
       ctx.events.on("agent.run.failed", async (event: PluginEvent) => {
+        // Post to errors channel
         await notify(event, formatAgentError, config.errorsChannelId);
+        // Also post to the issue thread if available
+        const payload = event.payload as Record<string, unknown>;
+        const issueId = payload.issueId ? String(payload.issueId) : null;
+        if (issueId) {
+          const threadTs = await ctx.state.get({
+            scopeKind: "company",
+            scopeId: event.companyId,
+            stateKey: STATE_KEYS.threadIssue(issueId),
+          });
+          if (threadTs) {
+            await notify(event, formatAgentError, undefined, { threadTs: String(threadTs) });
+          }
+        }
       });
     }
 
@@ -872,6 +926,102 @@ const plugin = definePlugin({
         await ctx.metrics.write("slack.budget_alerts.sent", 1, { threshold: String(bucket) });
       });
     }
+
+    // =========================================================================
+    // Goal & Project — thread-based notifications
+    // =========================================================================
+
+    ctx.events.on("goal.created", async (event: PluginEvent) => {
+      const result = await notify(event, formatGoalCreated);
+      if (result?.ok && result.ts) {
+        await ctx.state.set(
+          { scopeKind: "company", scopeId: event.companyId, stateKey: STATE_KEYS.threadGoal(event.entityId ?? "") },
+          result.ts,
+        );
+      }
+    });
+
+    ctx.events.on("goal.updated", async (event: PluginEvent) => {
+      const threadTs = await ctx.state.get({
+        scopeKind: "company",
+        scopeId: event.companyId,
+        stateKey: STATE_KEYS.threadGoal(event.entityId ?? ""),
+      });
+      await notify(event, formatGoalUpdated, undefined, threadTs ? { threadTs: String(threadTs) } : undefined);
+    });
+
+    ctx.events.on("project.created", async (event: PluginEvent) => {
+      const payload = event.payload as Record<string, unknown>;
+      // Try to thread under the parent goal
+      const goalId = payload.goalId ? String(payload.goalId) : null;
+      let threadTs: string | null = null;
+      if (goalId) {
+        const raw = await ctx.state.get({
+          scopeKind: "company",
+          scopeId: event.companyId,
+          stateKey: STATE_KEYS.threadGoal(goalId),
+        });
+        threadTs = raw ? String(raw) : null;
+      }
+      const result = await notify(event, formatProjectCreated, undefined, threadTs ? { threadTs } : undefined);
+      // Save project thread (use its own message or goal thread)
+      if (result?.ok && result.ts) {
+        await ctx.state.set(
+          { scopeKind: "company", scopeId: event.companyId, stateKey: STATE_KEYS.threadProject(event.entityId ?? "") },
+          threadTs ?? result.ts,
+        );
+      }
+    });
+
+    ctx.events.on("project.updated", async (event: PluginEvent) => {
+      const threadTs = await ctx.state.get({
+        scopeKind: "company",
+        scopeId: event.companyId,
+        stateKey: STATE_KEYS.threadProject(event.entityId ?? ""),
+      });
+      await notify(event, formatProjectUpdated, undefined, threadTs ? { threadTs: String(threadTs) } : undefined);
+    });
+
+    // =========================================================================
+    // Issue comments — thread reply under the issue
+    // =========================================================================
+
+    ctx.events.on("issue.comment.created", async (event: PluginEvent) => {
+      const threadTs = await ctx.state.get({
+        scopeKind: "company",
+        scopeId: event.companyId,
+        stateKey: STATE_KEYS.threadIssue(event.entityId ?? ""),
+      });
+      if (threadTs) {
+        await notify(event, formatCommentCreated, undefined, { threadTs: String(threadTs) });
+      }
+    });
+
+    // =========================================================================
+    // Agent run started — thread reply under the issue being worked on
+    // =========================================================================
+
+    ctx.events.on("agent.run.started", async (event: PluginEvent) => {
+      const payload = event.payload as Record<string, unknown>;
+      const issueId = payload.issueId ? String(payload.issueId) : event.entityId;
+      if (!issueId) return;
+      const threadTs = await ctx.state.get({
+        scopeKind: "company",
+        scopeId: event.companyId,
+        stateKey: STATE_KEYS.threadIssue(issueId),
+      });
+      if (threadTs) {
+        await notify(event, formatAgentRunStarted, undefined, { threadTs: String(threadTs) });
+      }
+    });
+
+    // =========================================================================
+    // Approval decided — thread reply
+    // =========================================================================
+
+    ctx.events.on("approval.decided", async (event: PluginEvent) => {
+      await notify(event, formatApprovalDecided, config.approvalsChannelId);
+    });
 
     // =========================================================================
     // Per-company channel overrides
@@ -1243,13 +1393,15 @@ const plugin = definePlugin({
     });
 
     // Collect events for watch checking (Phase 5)
-    const watchableEvents: Array<"issue.created" | "issue.updated" | "agent.run.failed" | "agent.run.finished" | "agent.status_changed" | "cost_event.created" | "approval.created"> = [
-      "issue.created", "issue.updated",
-      "agent.run.failed", "agent.run.finished", "agent.status_changed",
-      "cost_event.created", "approval.created",
+    const watchableEvents: Array<string> = [
+      "issue.created", "issue.updated", "issue.comment.created",
+      "agent.run.started", "agent.run.failed", "agent.run.finished", "agent.status_changed",
+      "goal.created", "goal.updated",
+      "project.created", "project.updated",
+      "cost_event.created", "approval.created", "approval.decided",
     ];
     for (const eventType of watchableEvents) {
-      ctx.events.on(eventType, async (event: PluginEvent) => {
+      ctx.events.on(eventType as Parameters<typeof ctx.events.on>[0], async (event: PluginEvent) => {
         const recentEventsRaw = await ctx.state.get({
           scopeKind: "company",
           scopeId: event.companyId,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -950,12 +950,46 @@ const plugin = definePlugin({
             }
           }
 
+          // Build per-agent breakdown and issue lists
+          const agentMap = new Map<string, string>();
+          for (const a of agents) agentMap.set(a.id, a.name);
+
+          const agentStats: Record<string, { completed: number; inProgress: number; created: number }> = {};
+          const completedIssues: Array<{ identifier: string; title: string; agentName: string }> = [];
+          const inProgressIssues: Array<{ identifier: string; title: string; agentName: string }> = [];
+          const createdIssues: Array<{ identifier: string; title: string; agentName: string }> = [];
+
+          for (const issue of issues) {
+            const updated = new Date(issue.updatedAt);
+            const created = new Date(issue.createdAt);
+            const agentName = issue.assigneeAgentId ? (agentMap.get(issue.assigneeAgentId) ?? "미할당") : "미할당";
+
+            if (!agentStats[agentName]) agentStats[agentName] = { completed: 0, inProgress: 0, created: 0 };
+
+            if (issue.status === "done" && updated >= dayAgo) {
+              agentStats[agentName].completed++;
+              completedIssues.push({ identifier: issue.identifier ?? issue.id.slice(0, 8), title: issue.title ?? "", agentName });
+            }
+            if (issue.status === "in_progress") {
+              agentStats[agentName].inProgress++;
+              inProgressIssues.push({ identifier: issue.identifier ?? issue.id.slice(0, 8), title: issue.title ?? "", agentName });
+            }
+            if (created >= dayAgo) {
+              agentStats[agentName].created++;
+              createdIssues.push({ identifier: issue.identifier ?? issue.id.slice(0, 8), title: issue.title ?? "", agentName });
+            }
+          }
+
           await postMessage(ctx, token, channelId, formatDailyDigest({
             tasksCompleted,
             tasksCreated,
             agentsActive,
             totalCost,
             topAgent,
+            agentStats,
+            completedIssues: completedIssues.slice(0, 10),
+            inProgressIssues: inProgressIssues.slice(0, 10),
+            createdIssues: createdIssues.slice(0, 10),
           }));
 
           // Clean up previous day's cost state

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -42,8 +42,6 @@ import {
   formatGoalUpdated,
   formatProjectCreated,
   formatProjectUpdated,
-  formatCommentCreated,
-  formatAgentRunStarted,
   formatApprovalDecided,
 } from "./formatters.js";
 import { processMediaFile, isMediaFile } from "./media-pipeline.js";
@@ -985,35 +983,6 @@ const plugin = definePlugin({
     // =========================================================================
     // Issue comments — thread reply under the issue
     // =========================================================================
-
-    ctx.events.on("issue.comment.created", async (event: PluginEvent) => {
-      const threadTs = await ctx.state.get({
-        scopeKind: "company",
-        scopeId: event.companyId,
-        stateKey: STATE_KEYS.threadIssue(event.entityId ?? ""),
-      });
-      if (threadTs) {
-        await notify(event, formatCommentCreated, undefined, { threadTs: String(threadTs) });
-      }
-    });
-
-    // =========================================================================
-    // Agent run started — thread reply under the issue being worked on
-    // =========================================================================
-
-    ctx.events.on("agent.run.started", async (event: PluginEvent) => {
-      const payload = event.payload as Record<string, unknown>;
-      const issueId = payload.issueId ? String(payload.issueId) : event.entityId;
-      if (!issueId) return;
-      const threadTs = await ctx.state.get({
-        scopeKind: "company",
-        scopeId: event.companyId,
-        stateKey: STATE_KEYS.threadIssue(issueId),
-      });
-      if (threadTs) {
-        await notify(event, formatAgentRunStarted, undefined, { threadTs: String(threadTs) });
-      }
-    });
 
     // =========================================================================
     // Approval decided — thread reply

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -929,8 +929,11 @@ const plugin = definePlugin({
     // Goal & Project — thread-based notifications
     // =========================================================================
 
+    // Goal/Project → #_general (큰 주제는 공지 채널)
+    const GENERAL_CHANNEL = "C05RA9YNLQH"; // #_general
+
     ctx.events.on("goal.created", async (event: PluginEvent) => {
-      const result = await notify(event, formatGoalCreated);
+      const result = await notify(event, formatGoalCreated, GENERAL_CHANNEL);
       if (result?.ok && result.ts) {
         await ctx.state.set(
           { scopeKind: "company", scopeId: event.companyId, stateKey: STATE_KEYS.threadGoal(event.entityId ?? "") },
@@ -945,7 +948,7 @@ const plugin = definePlugin({
         scopeId: event.companyId,
         stateKey: STATE_KEYS.threadGoal(event.entityId ?? ""),
       });
-      await notify(event, formatGoalUpdated, undefined, threadTs ? { threadTs: String(threadTs) } : undefined);
+      await notify(event, formatGoalUpdated, GENERAL_CHANNEL, threadTs ? { threadTs: String(threadTs) } : undefined);
     });
 
     ctx.events.on("project.created", async (event: PluginEvent) => {
@@ -961,7 +964,7 @@ const plugin = definePlugin({
         });
         threadTs = raw ? String(raw) : null;
       }
-      const result = await notify(event, formatProjectCreated, undefined, threadTs ? { threadTs } : undefined);
+      const result = await notify(event, formatProjectCreated, GENERAL_CHANNEL, threadTs ? { threadTs } : undefined);
       // Save project thread (use its own message or goal thread)
       if (result?.ok && result.ts) {
         await ctx.state.set(
@@ -977,7 +980,7 @@ const plugin = definePlugin({
         scopeId: event.companyId,
         stateKey: STATE_KEYS.threadProject(event.entityId ?? ""),
       });
-      await notify(event, formatProjectUpdated, undefined, threadTs ? { threadTs: String(threadTs) } : undefined);
+      await notify(event, formatProjectUpdated, GENERAL_CHANNEL, threadTs ? { threadTs: String(threadTs) } : undefined);
     });
 
     // =========================================================================

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -26,6 +26,7 @@ import {
   setBaseUrl,
   formatIssueCreated,
   formatIssueDone,
+  formatIssueStatusChanged,
   formatApprovalCreated,
   formatApprovalResolved,
   formatAgentError,
@@ -723,12 +724,25 @@ const plugin = definePlugin({
     // Notification helper (supports per-type channel override + threading)
     // =========================================================================
 
+    // Dedup: skip events already processed (prevents double-posting)
+    const recentEvents = new Set<string>();
+    const DEDUP_TTL_MS = 30_000;
+
     const notify = async (
       event: PluginEvent,
       formatter: (e: PluginEvent) => SlackMessage,
       overrideChannelId?: string,
       opts?: { threadTs?: string },
     ) => {
+      // Dedup guard — skip if same eventId already processed
+      const dedupKey = `${event.eventId}:${event.eventType}`;
+      if (recentEvents.has(dedupKey)) {
+        ctx.logger.debug("Skipping duplicate event", { eventId: event.eventId, eventType: event.eventType });
+        return;
+      }
+      recentEvents.add(dedupKey);
+      setTimeout(() => recentEvents.delete(dedupKey), DEDUP_TTL_MS);
+
       const fallback = overrideChannelId || config.defaultChannelId;
       const channelId = await resolveChannel(ctx, event.companyId, fallback);
       if (!channelId) return;
@@ -754,27 +768,40 @@ const plugin = definePlugin({
     if (config.notifyOnIssueCreated) {
       ctx.events.on("issue.created", async (event: PluginEvent) => {
         const result = await notify(event, formatIssueCreated);
+        ctx.logger.info("issue.created notify result", { entityId: event.entityId, ok: result?.ok, ts: result?.ts });
         if (result?.ok && result.ts) {
+          const stateKey = STATE_KEYS.threadIssue(event.entityId ?? "");
           await ctx.state.set(
-            { scopeKind: "company", scopeId: event.companyId, stateKey: STATE_KEYS.threadIssue(event.entityId ?? "") },
+            { scopeKind: "company", scopeId: event.companyId, stateKey },
             result.ts,
           );
+          ctx.logger.info("Saved thread_ts for issue", { entityId: event.entityId, stateKey, threadTs: result.ts });
         }
       });
     }
 
-    if (config.notifyOnIssueDone) {
-      ctx.events.on("issue.updated", async (event: PluginEvent) => {
-        const payload = event.payload as Record<string, unknown>;
-        if (payload.status !== "done") return;
-        const threadTs = await ctx.state.get({
-          scopeKind: "company",
-          scopeId: event.companyId,
-          stateKey: STATE_KEYS.threadIssue(event.entityId ?? ""),
-        }) as string | null;
-        await notify(event, formatIssueDone, undefined, threadTs ? { threadTs } : undefined);
+    // issue.updated — all status changes go to the same thread as issue.created
+    ctx.events.on("issue.updated", async (event: PluginEvent) => {
+      const payload = event.payload as Record<string, unknown>;
+      const status = payload.status ? String(payload.status) : null;
+      if (!status) return;
+
+      // Look up the original thread for this issue (state may return number — force string)
+      const stateKey = STATE_KEYS.threadIssue(event.entityId ?? "");
+      const rawThreadTs = await ctx.state.get({
+        scopeKind: "company",
+        scopeId: event.companyId,
+        stateKey,
       });
-    }
+      const threadTs = rawThreadTs != null ? String(rawThreadTs) : null;
+      ctx.logger.info("issue.updated thread lookup", { entityId: event.entityId, stateKey, threadTs, status });
+
+      if (status === "done" && config.notifyOnIssueDone) {
+        await notify(event, formatIssueDone, undefined, threadTs ? { threadTs } : undefined);
+      } else if (status !== "done" && (config as Record<string, unknown>).notifyOnIssueUpdated !== false) {
+        await notify(event, formatIssueStatusChanged, undefined, threadTs ? { threadTs } : undefined);
+      }
+    });
 
     if (config.notifyOnApprovalCreated) {
       ctx.events.on("approval.created", async (event: PluginEvent) => {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -984,7 +984,6 @@ const plugin = definePlugin({
             tasksCompleted,
             tasksCreated,
             agentsActive,
-            totalCost,
             topAgent,
             agentStats,
             completedIssues: completedIssues.slice(0, 10),

--- a/tests/dgg646-dedup.test.ts
+++ b/tests/dgg646-dedup.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import type { PluginEvent } from "@paperclipai/plugin-sdk";
+import {
+  formatIssueCreated,
+  formatIssueDone,
+  formatIssueStatusChanged,
+} from "../src/formatters.js";
+
+function mockEvent(eventType: string, payload: Record<string, unknown> = {}): PluginEvent {
+  return {
+    eventType,
+    entityId: "issue-123",
+    companyId: "company-1",
+    occurredAt: "2026-04-12T10:00:00.000Z",
+    payload: {
+      identifier: "DGG-123",
+      title: "Notifier duplication investigation",
+      status: "in_progress",
+      assigneeName: "Badtz Dev",
+      ...payload,
+    },
+  } as PluginEvent;
+}
+
+function firstSectionText(message: { blocks?: Array<Record<string, unknown>> }): string {
+  const firstSection = message.blocks?.find((b) => b.type === "section" && b.text) as
+    | Record<string, unknown>
+    | undefined;
+  if (!firstSection) return "";
+  return String((firstSection.text as Record<string, unknown>).text ?? "");
+}
+
+describe("DGG-646 notifier compose dedup", () => {
+  it("issue.created fallback text should not duplicate title already in block body", () => {
+    const msg = formatIssueCreated(mockEvent("issue.created"));
+    const section = firstSectionText(msg);
+
+    expect(msg.text).toContain("새 이슈");
+    expect(msg.text).not.toContain("Notifier duplication investigation");
+    expect(section).toContain("Notifier duplication investigation");
+  });
+
+  it("issue.status_changed fallback text should only carry status headline", () => {
+    const msg = formatIssueStatusChanged(
+      mockEvent("issue.status_changed", {
+        description: "## Execution Update\n- Notifier duplication investigation",
+      }),
+    );
+    const section = firstSectionText(msg);
+
+    expect(msg.text).toContain("진행 중");
+    expect(msg.text).not.toContain("Notifier duplication investigation");
+    expect(section).toContain("Notifier duplication investigation");
+  });
+
+  it("issue.done fallback text should not repeat title rendered in block", () => {
+    const msg = formatIssueDone(
+      mockEvent("issue.done", {
+        description: "## Execution Update\n- Notifier duplication investigation",
+      }),
+    );
+    const section = firstSectionText(msg);
+
+    expect(msg.text).toContain("완료");
+    expect(msg.text).not.toContain("Notifier duplication investigation");
+    expect(section).toContain("Notifier duplication investigation");
+  });
+});


### PR DESCRIPTION
## Summary
- Remove duplicated headline composition in issue notification formatters (`issue.created`, `issue.status_changed`, `issue.done`).
- Keep Slack block body focused on title/summary/meta, while fallback `text` keeps concise status headline only.
- Add targeted regression tests for DGG-646 to prevent fallback+block duplication regression.

## RCA
Notifier payloads were composing the same headline in two places:
1) top-level fallback `text`
2) first block section body

Downstream consumers that flatten both fields into one rendered body (or logs) surfaced this as duplicated in-message content.

## Validation
- `npm run build`
- `npx vitest run tests/dgg646-dedup.test.ts`
