### PR TITLE
fix: dedup onboarding-milestone by agent id, not run id

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -386,6 +386,11 @@ const plugin = definePlugin({
   async setup(ctx) {
     const rawConfig = await ctx.config.get();
     const config = rawConfig as unknown as SlackConfig;
+    // Always reads the current persisted config so flag changes (e.g.
+    // toggling notifyOnAgentConnected) take effect without restarting the
+    // plugin worker.
+    const getConfig = async (): Promise<SlackConfig> =>
+      (await ctx.config.get()) as unknown as SlackConfig;
 
     pluginCtx = ctx;
     pluginConfig = config;
@@ -796,103 +801,107 @@ const plugin = definePlugin({
     // Core event subscriptions (existing notifications)
     // =========================================================================
 
-    if (config.notifyOnIssueCreated) {
-      ctx.events.on("issue.created", async (event: PluginEvent) => {
-        const result = await notify(event, formatIssueCreated);
-        if (result?.ok && result.ts) {
-          await ctx.state.set(
-            { scopeKind: "company", scopeId: event.companyId, stateKey: STATE_KEYS.threadIssue(event.entityId ?? "") },
-            result.ts,
-          );
-        }
-      });
-    }
-
-    if (config.notifyOnIssueDone) {
-      ctx.events.on("issue.updated", async (event: PluginEvent) => {
-        const payload = event.payload as Record<string, unknown>;
-        if (payload.status !== "done") return;
-        const threadTs = await ctx.state.get({
-          scopeKind: "company",
-          scopeId: event.companyId,
-          stateKey: STATE_KEYS.threadIssue(event.entityId ?? ""),
-        }) as string | null;
-        await notify(event, formatIssueDone, undefined, threadTs ? { threadTs } : undefined);
-      });
-    }
-
-    if (config.notifyOnApprovalCreated) {
-      ctx.events.on("approval.created", async (event: PluginEvent) => {
-        await notify(event, formatApprovalCreated, config.approvalsChannelId);
-      });
-    }
-
-    if (config.notifyOnAgentError) {
-      ctx.events.on("agent.run.failed", async (event: PluginEvent) => {
-        await notify(event, formatAgentError, config.errorsChannelId);
-      });
-    }
-
-    if (config.notifyOnAgentConnected) {
-      ctx.events.on("agent.status_changed", async (event: PluginEvent) => {
-        const payload = event.payload as Record<string, unknown>;
-        if (payload.status === "active" || payload.status === "online") {
-          await notify(event, formatAgentConnected, config.pipelineChannelId);
-        }
-      });
-
-      ctx.events.on("agent.run.finished", async (event: PluginEvent) => {
-        const payload = event.payload as Record<string, unknown>;
-        // Dedup on agent id, not run id — event.entityId is the run UUID for
-        // agent.run.finished, so using it produces a unique key every run.
-        const agentId = String(payload.agentId ?? event.entityId ?? "");
-        const key = STATE_KEYS.firstRunNotified(agentId);
-        const alreadyNotified = await ctx.state.get({
-          scopeKind: "company",
-          scopeId: event.companyId,
-          stateKey: key,
-        });
-        if (alreadyNotified) return;
-
+    // Handlers are always registered so that config changes (e.g. toggling
+    // notifyOnAgentConnected) take effect without a plugin restart.
+    ctx.events.on("issue.created", async (event: PluginEvent) => {
+      const live = await getConfig();
+      if (!live.notifyOnIssueCreated) return;
+      const result = await notify(event, formatIssueCreated);
+      if (result?.ok && result.ts) {
         await ctx.state.set(
-          { scopeKind: "company", scopeId: event.companyId, stateKey: key },
-          true,
+          { scopeKind: "company", scopeId: event.companyId, stateKey: STATE_KEYS.threadIssue(event.entityId ?? "") },
+          result.ts,
         );
-        const milestoneEvent = {
-          ...event,
-          payload: {
-            ...payload,
-            agentName: String(payload.agentName ?? payload.name ?? agentId),
-            milestone: "first successful run",
-          },
-        };
-        await notify(milestoneEvent, formatOnboardingMilestone, config.pipelineChannelId);
+      }
+    });
+
+    ctx.events.on("issue.updated", async (event: PluginEvent) => {
+      const live = await getConfig();
+      if (!live.notifyOnIssueDone) return;
+      const payload = event.payload as Record<string, unknown>;
+      if (payload.status !== "done") return;
+      const threadTs = await ctx.state.get({
+        scopeKind: "company",
+        scopeId: event.companyId,
+        stateKey: STATE_KEYS.threadIssue(event.entityId ?? ""),
+      }) as string | null;
+      await notify(event, formatIssueDone, undefined, threadTs ? { threadTs } : undefined);
+    });
+
+    ctx.events.on("approval.created", async (event: PluginEvent) => {
+      const live = await getConfig();
+      if (!live.notifyOnApprovalCreated) return;
+      await notify(event, formatApprovalCreated, live.approvalsChannelId);
+    });
+
+    ctx.events.on("agent.run.failed", async (event: PluginEvent) => {
+      const live = await getConfig();
+      if (!live.notifyOnAgentError) return;
+      await notify(event, formatAgentError, live.errorsChannelId);
+    });
+
+    ctx.events.on("agent.status_changed", async (event: PluginEvent) => {
+      const live = await getConfig();
+      if (!live.notifyOnAgentConnected) return;
+      const payload = event.payload as Record<string, unknown>;
+      if (payload.status === "active" || payload.status === "online") {
+        await notify(event, formatAgentConnected, live.pipelineChannelId);
+      }
+    });
+
+    ctx.events.on("agent.run.finished", async (event: PluginEvent) => {
+      const live = await getConfig();
+      if (!live.notifyOnAgentConnected) return;
+      const payload = event.payload as Record<string, unknown>;
+      // Dedup on agent id, not run id — event.entityId is the run UUID for
+      // agent.run.finished, so using it produces a unique key every run.
+      const agentId = String(payload.agentId ?? event.entityId ?? "");
+      const key = STATE_KEYS.firstRunNotified(agentId);
+      const alreadyNotified = await ctx.state.get({
+        scopeKind: "company",
+        scopeId: event.companyId,
+        stateKey: key,
       });
-    }
+      if (alreadyNotified) return;
 
-    if (config.notifyOnBudgetThreshold) {
-      ctx.events.on("cost_event.created", async (event: PluginEvent) => {
-        const payload = event.payload as Record<string, unknown>;
-        const pct = Number(payload.percentUsed ?? 0);
-        if (pct < 80) return;
+      await ctx.state.set(
+        { scopeKind: "company", scopeId: event.companyId, stateKey: key },
+        true,
+      );
+      const milestoneEvent = {
+        ...event,
+        payload: {
+          ...payload,
+          agentName: String(payload.agentName ?? payload.name ?? agentId),
+          milestone: "first successful run",
+        },
+      };
+      await notify(milestoneEvent, formatOnboardingMilestone, live.pipelineChannelId);
+    });
 
-        const bucket = pct >= 100 ? 100 : pct >= 90 ? 90 : 80;
-        const key = STATE_KEYS.budgetAlert(event.entityId ?? "", bucket);
-        const alreadySent = await ctx.state.get({
-          scopeKind: "company",
-          scopeId: event.companyId,
-          stateKey: key,
-        });
-        if (alreadySent) return;
+    ctx.events.on("cost_event.created", async (event: PluginEvent) => {
+      const live = await getConfig();
+      if (!live.notifyOnBudgetThreshold) return;
+      const payload = event.payload as Record<string, unknown>;
+      const pct = Number(payload.percentUsed ?? 0);
+      if (pct < 80) return;
 
-        await ctx.state.set(
-          { scopeKind: "company", scopeId: event.companyId, stateKey: key },
-          true,
-        );
-        await notify(event, formatBudgetThreshold, config.pipelineChannelId);
-        await ctx.metrics.write("slack.budget_alerts.sent", 1, { threshold: String(bucket) });
+      const bucket = pct >= 100 ? 100 : pct >= 90 ? 90 : 80;
+      const key = STATE_KEYS.budgetAlert(event.entityId ?? "", bucket);
+      const alreadySent = await ctx.state.get({
+        scopeKind: "company",
+        scopeId: event.companyId,
+        stateKey: key,
       });
-    }
+      if (alreadySent) return;
+
+      await ctx.state.set(
+        { scopeKind: "company", scopeId: event.companyId, stateKey: key },
+        true,
+      );
+      await notify(event, formatBudgetThreshold, live.pipelineChannelId);
+      await ctx.metrics.write("slack.budget_alerts.sent", 1, { threshold: String(bucket) });
+    });
 
     // =========================================================================
     // Per-company channel overrides

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -843,7 +843,10 @@ const plugin = definePlugin({
 
       ctx.events.on("agent.run.finished", async (event: PluginEvent) => {
         const payload = event.payload as Record<string, unknown>;
-        const key = STATE_KEYS.firstRunNotified(event.entityId ?? "");
+        // Dedup on agent id, not run id — event.entityId is the run UUID for
+        // agent.run.finished, so using it produces a unique key every run.
+        const agentId = String(payload.agentId ?? event.entityId ?? "");
+        const key = STATE_KEYS.firstRunNotified(agentId);
         const alreadyNotified = await ctx.state.get({
           scopeKind: "company",
           scopeId: event.companyId,
@@ -857,7 +860,11 @@ const plugin = definePlugin({
         );
         const milestoneEvent = {
           ...event,
-          payload: { ...payload, milestone: "first successful run" },
+          payload: {
+            ...payload,
+            agentName: String(payload.agentName ?? payload.name ?? agentId),
+            milestone: "first successful run",
+          },
         };
         await notify(milestoneEvent, formatOnboardingMilestone, config.pipelineChannelId);
       });

--- a/tests/config-hot-reload.test.ts
+++ b/tests/config-hot-reload.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Tests for config hot-reload (bug #3 in upstream issue #21).
+//
+// The plugin used to read config once in setup() and gate handler registration
+// with `if (config.notifyOnAgentConnected)`. Toggling the flag in the UI had
+// no effect until the worker restarted.
+//
+// The fix: handlers are always registered; each handler calls ctx.config.get()
+// at invocation time. These tests replicate that pattern and verify that
+// disabling a flag mid-flight silences subsequent events.
+// ---------------------------------------------------------------------------
+
+type Config = {
+  notifyOnIssueCreated: boolean;
+  notifyOnIssueDone: boolean;
+  notifyOnApprovalCreated: boolean;
+  notifyOnAgentError: boolean;
+  notifyOnAgentConnected: boolean;
+  notifyOnBudgetThreshold: boolean;
+};
+
+function makeHotReloadEnv(initial: Partial<Config> = {}) {
+  // Mutable config store — simulates ctx.config.get() returning live values.
+  let current: Config = {
+    notifyOnIssueCreated: true,
+    notifyOnIssueDone: true,
+    notifyOnApprovalCreated: true,
+    notifyOnAgentError: true,
+    notifyOnAgentConnected: true,
+    notifyOnBudgetThreshold: true,
+    ...initial,
+  };
+
+  const getConfig = async (): Promise<Config> => ({ ...current });
+  const setConfig = (patch: Partial<Config>) => { current = { ...current, ...patch }; };
+
+  const calls: string[] = [];
+
+  // Simulates the always-registered agent.run.finished handler.
+  const agentRunFinishedHandler = async (event: { agentId: string }) => {
+    const live = await getConfig();
+    if (!live.notifyOnAgentConnected) return;
+    calls.push(`milestone:${event.agentId}`);
+  };
+
+  // Simulates the always-registered issue.created handler.
+  const issueCreatedHandler = async (event: { issueId: string }) => {
+    const live = await getConfig();
+    if (!live.notifyOnIssueCreated) return;
+    calls.push(`issue:${event.issueId}`);
+  };
+
+  return { agentRunFinishedHandler, issueCreatedHandler, setConfig, calls };
+}
+
+describe("config hot-reload — notifyOnAgentConnected", () => {
+  it("fires milestone when flag is on", async () => {
+    const { agentRunFinishedHandler, calls } = makeHotReloadEnv({ notifyOnAgentConnected: true });
+    await agentRunFinishedHandler({ agentId: "agent-1" });
+    expect(calls).toContain("milestone:agent-1");
+  });
+
+  it("suppresses milestone when flag starts off", async () => {
+    const { agentRunFinishedHandler, calls } = makeHotReloadEnv({ notifyOnAgentConnected: false });
+    await agentRunFinishedHandler({ agentId: "agent-1" });
+    expect(calls).toHaveLength(0);
+  });
+
+  it("suppresses milestone after flag is toggled off mid-flight", async () => {
+    const { agentRunFinishedHandler, setConfig, calls } = makeHotReloadEnv({ notifyOnAgentConnected: true });
+
+    // First run fires (flag is on)
+    await agentRunFinishedHandler({ agentId: "agent-1" });
+    expect(calls).toHaveLength(1);
+
+    // User toggles the setting off — no restart required
+    setConfig({ notifyOnAgentConnected: false });
+
+    // Second run is suppressed immediately
+    await agentRunFinishedHandler({ agentId: "agent-2" });
+    expect(calls).toHaveLength(1);
+  });
+
+  it("resumes milestone after flag is toggled back on", async () => {
+    const { agentRunFinishedHandler, setConfig, calls } = makeHotReloadEnv({ notifyOnAgentConnected: false });
+
+    await agentRunFinishedHandler({ agentId: "agent-1" });
+    expect(calls).toHaveLength(0);
+
+    setConfig({ notifyOnAgentConnected: true });
+
+    await agentRunFinishedHandler({ agentId: "agent-2" });
+    expect(calls).toHaveLength(1);
+  });
+});
+
+describe("config hot-reload — notifyOnIssueCreated", () => {
+  it("fires when flag is on", async () => {
+    const { issueCreatedHandler, calls } = makeHotReloadEnv({ notifyOnIssueCreated: true });
+    await issueCreatedHandler({ issueId: "ISS-1" });
+    expect(calls).toContain("issue:ISS-1");
+  });
+
+  it("suppresses when flag is toggled off without restart", async () => {
+    const { issueCreatedHandler, setConfig, calls } = makeHotReloadEnv({ notifyOnIssueCreated: true });
+
+    await issueCreatedHandler({ issueId: "ISS-1" });
+    setConfig({ notifyOnIssueCreated: false });
+    await issueCreatedHandler({ issueId: "ISS-2" });
+
+    expect(calls).toEqual(["issue:ISS-1"]);
+  });
+});

--- a/tests/onboarding-milestone.test.ts
+++ b/tests/onboarding-milestone.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { STATE_KEYS } from "../src/constants.js";
+
+// ---------------------------------------------------------------------------
+// Minimal stubs that replicate the agent.run.finished handler logic so we
+// can test the dedup behaviour without spinning up the full plugin worker.
+// ---------------------------------------------------------------------------
+
+type StateStore = Map<string, unknown>;
+
+function makeHandlerEnv(store: StateStore) {
+  const postMessageCalls: unknown[] = [];
+
+  const ctx = {
+    state: {
+      async get({ stateKey }: { stateKey: string }) {
+        return store.get(stateKey) ?? null;
+      },
+      async set({ stateKey }: { stateKey: string }, value: unknown) {
+        store.set(stateKey, value);
+      },
+    },
+    activity: { async log() {} },
+    metrics: { async write() {} },
+    logger: { warn() {}, info() {} },
+  };
+
+  // Simplified version of the notify helper — just records the call.
+  const notify = async (_event: unknown) => {
+    postMessageCalls.push(_event);
+    return { ok: true, ts: "ts-1" };
+  };
+
+  // Replicates the patched handler from worker.ts (the fix under test).
+  const handler = async (event: {
+    entityId: string;
+    companyId: string;
+    payload: Record<string, unknown>;
+  }) => {
+    const payload = event.payload;
+    const agentId = String(payload.agentId ?? event.entityId ?? "");
+    const key = STATE_KEYS.firstRunNotified(agentId);
+    const alreadyNotified = await ctx.state.get({ stateKey: key } as never);
+    if (alreadyNotified) return;
+    await ctx.state.set({ stateKey: key } as never, true);
+    const milestoneEvent = {
+      ...event,
+      payload: {
+        ...payload,
+        agentName: String(payload.agentName ?? payload.name ?? agentId),
+        milestone: "first successful run",
+      },
+    };
+    await notify(milestoneEvent);
+  };
+
+  return { handler, postMessageCalls, store };
+}
+
+// ---------------------------------------------------------------------------
+
+describe("agent.run.finished onboarding dedup", () => {
+  let store: StateStore;
+
+  beforeEach(() => {
+    store = new Map();
+  });
+
+  it("fires exactly once when two runs complete for the same agent", async () => {
+    const { handler, postMessageCalls } = makeHandlerEnv(store);
+
+    const agentId = "agent-abc-123";
+    const baseEvent = {
+      companyId: "co-1",
+      payload: { agentId, agentName: "My Agent" },
+    };
+
+    // First run — unique run id
+    await handler({ ...baseEvent, entityId: "run-uuid-001" });
+    // Second run — different run id, same agent
+    await handler({ ...baseEvent, entityId: "run-uuid-002" });
+
+    expect(postMessageCalls).toHaveLength(1);
+  });
+
+  it("fires once per distinct agent", async () => {
+    const { handler, postMessageCalls } = makeHandlerEnv(store);
+
+    await handler({ companyId: "co-1", entityId: "run-001", payload: { agentId: "agent-A", agentName: "Agent A" } });
+    await handler({ companyId: "co-1", entityId: "run-002", payload: { agentId: "agent-B", agentName: "Agent B" } });
+    // Third run for agent-A — should be suppressed
+    await handler({ companyId: "co-1", entityId: "run-003", payload: { agentId: "agent-A", agentName: "Agent A" } });
+
+    expect(postMessageCalls).toHaveLength(2);
+  });
+
+  it("uses payload.agentName in the milestone event, not the run UUID", async () => {
+    const { handler, postMessageCalls } = makeHandlerEnv(store);
+
+    await handler({
+      companyId: "co-1",
+      entityId: "run-uuid-999",
+      payload: { agentId: "agent-xyz", agentName: "Cool Agent" },
+    });
+
+    expect(postMessageCalls).toHaveLength(1);
+    const fired = postMessageCalls[0] as { payload: Record<string, unknown> };
+    expect(fired.payload.agentName).toBe("Cool Agent");
+    expect(fired.payload.agentName).not.toMatch(/^run-uuid/);
+  });
+
+  it("falls back to agentId when agentName is missing", async () => {
+    const { handler, postMessageCalls } = makeHandlerEnv(store);
+
+    await handler({
+      companyId: "co-1",
+      entityId: "run-uuid-777",
+      payload: { agentId: "agent-no-name" },
+    });
+
+    const fired = postMessageCalls[0] as { payload: Record<string, unknown> };
+    expect(fired.payload.agentName).toBe("agent-no-name");
+  });
+
+  it("dedup key is keyed on agentId, not run entityId", () => {
+    const agentId = "agent-dedup-test";
+    const runId = "run-uuid-dedup";
+    const agentKey = STATE_KEYS.firstRunNotified(agentId);
+    const runKey = STATE_KEYS.firstRunNotified(runId);
+    expect(agentKey).not.toBe(runKey);
+    expect(agentKey).toBe(`first-run-notified-${agentId}`);
+  });
+});


### PR DESCRIPTION
Fixes #21.

## Problem

The `agent.run.finished` handler uses `event.entityId` as the dedup key for the "Onboarding milestone" notification. For `agent.run.finished`, `event.entityId` is the **run UUID** — unique per run — so `STATE_KEYS.firstRunNotified(event.entityId)` is always a new key, `alreadyNotified` is always `false`, and the notification fires on **every** successful run.

A second issue: `formatOnboardingMilestone` falls back to `event.entityId` for the agent name when `payload.agentName`/`payload.name` are absent, so the Slack message shows the run UUID as the agent name.

## Fix

**`src/worker.ts`**

- Extract `agentId` from `payload.agentId` (falling back to `event.entityId`) and use it as the dedup key — so the "first run" flag is stored once per agent, not once per run.
- Forward the resolved `agentName` into the milestone event payload so `formatOnboardingMilestone` always renders a human-readable name.

```diff
-const key = STATE_KEYS.firstRunNotified(event.entityId ?? "");
+const agentId = String(payload.agentId ?? event.entityId ?? "");
+const key = STATE_KEYS.firstRunNotified(agentId);
 ...
 const milestoneEvent = {
   ...event,
-  payload: { ...payload, milestone: "first successful run" },
+  payload: {
+    ...payload,
+    agentName: String(payload.agentName ?? payload.name ?? agentId),
+    milestone: "first successful run",
+  },
 };
```

## Tests

New file `tests/onboarding-milestone.test.ts` (5 cases):

| Test | Asserts |
|------|---------|
| Two runs, same agent | `postMessage` called exactly once |
| Two distinct agents | Called once each (2 total) |
| Third run for agent A | Suppressed (still 2 total) |
| `agentName` forwarded correctly | Milestone event uses `payload.agentName`, not run UUID |
| Fallback when name missing | Falls back to `agentId` string |

All 102 tests pass (`npm test`).