### PR TITLE
docs: fix README pointing to non-existent "Settings → Secrets" page

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,12 @@ curl -X POST http://127.0.0.1:3100/api/plugins/install \
 2. Add the `chat:write` bot scope
 3. Enable **Interactivity** and point the Request URL to your Paperclip host's `slack-interactivity` webhook endpoint
 4. Install the app to your workspace and copy the Bot OAuth Token
-5. In Paperclip, go to **Settings -> Secrets** and create a new secret with your Bot OAuth Token. Copy the secret UUID.
+5. In Paperclip, create a **company secret** holding the Bot OAuth Token, by either:
+
+   - **UI:** Open any agent's **Configuration → Environment variables**, enter a name (e.g. `slack-bot-oauth-token`) and the Bot OAuth Token as the value, then click **Create / Seal**. The secret is created at the **company level** (not bound to that agent — despite the agent-context UI) and the returned UUID can be used from any plugin in the company.
+   - **REST API:** `POST /api/companies/{companyId}/secrets` with body `{"name": "slack-bot-oauth-token", "value": "<your-bot-oauth-token>", "provider": "local_encrypted"}`. The response contains the secret's UUID.
+
+   Copy the resulting secret UUID — you'll paste it into `slackTokenRef` in the next step.
 6. Install the plugin and configure the secret UUID in the `slackTokenRef` field + your default channel ID
 
 ## Configuration
@@ -181,7 +186,7 @@ The plugin registers these tools that agents can call:
 
 The `slackTokenRef` field now declares `format: "secret-ref"`, which is required for Paperclip to collect and resolve secret references at activation time. Previously, the field was a plain `string` with no format annotation, causing plugin activation to fail with `Invalid secret reference`.
 
-**If you installed v2.0.0:** you must re-configure the plugin. Go to **Settings -> Secrets**, create a secret with your Slack Bot OAuth Token, and paste the resulting secret UUID into the `slackTokenRef` field in the plugin configuration. Raw token strings are no longer accepted in this field.
+**If you installed v2.0.0:** you must re-configure the plugin. Create a company secret holding the Slack Bot OAuth Token using one of the paths in the [Setup](#setup) section above (UI or REST API), then paste the resulting secret UUID into the `slackTokenRef` field in the plugin configuration. Raw token strings are no longer accepted in this field.
 
 ## Development
 


### PR DESCRIPTION
## Summary

Fixes the README's `Settings → Secrets` instruction, which points to a non-existent page in current Paperclip — surfaced by user report in #5 and consolidated in #23.

## What changed

Replaces the bogus path in **Setup** and **v2.0.1 Migration** sections with two correct paths (verified against `paperclipai/paperclip` master):

- **UI:** Agent Configuration → Environment variables → enter name (e.g. `slack-bot-oauth-token`) + Bot OAuth Token → create/seal. Inline creation via `ui/src/components/AgentConfigForm.tsx:1127` (`onCreateSecret`). The secret is **company-scoped** despite the agent-context UI — that was the part that confused users.
- **REST API:** `POST /api/companies/{companyId}/secrets` with `{"name": "slack-bot-oauth-token", "value": ..., "provider": "local_encrypted"}`.

The Migration section was rewritten to reference Setup rather than duplicate the path — easier to keep in sync if the upstream UX changes.

## Verification

- Verified upstream truth at `paperclipai/paperclip` master (commit `0e1a5828`): no `/settings/secrets` route in `ui/src/App.tsx`, no standalone `Secrets.tsx` page; `secretsApi.create` is called from `AgentConfigForm.tsx:1127`.
- Cross-plugin scope: same fix in coordinated PRs for `paperclip-plugin-{telegram,discord}`.

## Related

- #5 — original user report; UUID-confusion sub-thread there. Worker-init failure in #5 stays tracked separately.
- mvanhorn/paperclip-plugin-telegram#23 (PR coming, same fix shape)
- mvanhorn/paperclip-plugin-discord#44 (PR coming, same fix shape)
- ACP plugin unaffected (no secret-creation instruction in its README)

Closes #23

---
<sub><em>**[@superbiche](https://github.com/superbiche)** · co-maintainer · drafted with Claude Opus 4.7, reviewed before posting; the voice and decisions are mine.</em></sub>