### PR TITLE
chore: align Paperclip SDK and plugin metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "paperclip-plugin-slack",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "paperclip-plugin-slack",
-      "version": "2.0.8",
+      "version": "2.0.9",
       "license": "MIT",
       "devDependencies": {
-        "@paperclipai/plugin-sdk": "^2026.318.0",
-        "@paperclipai/shared": "^2026.318.0",
+        "@paperclipai/plugin-sdk": "^2026.618.0",
+        "@paperclipai/shared": "^2026.618.0",
         "@types/node": "^25.5.2",
         "typescript": "^5.7.0",
         "vitest": "^3.0.0"
@@ -18,17 +18,6 @@
       "peerDependencies": {
         "@paperclipai/plugin-sdk": "*",
         "@paperclipai/shared": "*"
-      }
-    },
-    "../paperclip/packages/shared": {
-      "name": "@paperclipai/shared",
-      "version": "0.3.1",
-      "extraneous": true,
-      "dependencies": {
-        "zod": "^3.24.2"
-      },
-      "devDependencies": {
-        "typescript": "^5.7.3"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -481,13 +470,13 @@
       "license": "MIT"
     },
     "node_modules/@paperclipai/plugin-sdk": {
-      "version": "2026.318.0",
-      "resolved": "https://registry.npmjs.org/@paperclipai/plugin-sdk/-/plugin-sdk-2026.318.0.tgz",
-      "integrity": "sha512-bqRDdTXKZjh+DXS9f1R9YdRtTyBhewbxD1ENwJcz88PDszGg7V/1/pYjs2t0xJhG8QU9LJ8LTYagLOw7jpF4Og==",
+      "version": "2026.618.0",
+      "resolved": "https://registry.npmjs.org/@paperclipai/plugin-sdk/-/plugin-sdk-2026.618.0.tgz",
+      "integrity": "sha512-/8hoPh4x70/1HoaAe8Hofej1Ww5RLpMfbQb8fiXpRcLY9MkEN7XjzR0jVqTw4y2bwed+xQRhPJ5QRcviM/lPkA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@paperclipai/shared": "2026.318.0",
+        "@paperclipai/shared": "2026.618.0",
         "zod": "^3.24.2"
       },
       "bin": {
@@ -503,9 +492,9 @@
       }
     },
     "node_modules/@paperclipai/shared": {
-      "version": "2026.318.0",
-      "resolved": "https://registry.npmjs.org/@paperclipai/shared/-/shared-2026.318.0.tgz",
-      "integrity": "sha512-7ZtZN+Z0dpwVtusJ8X0R+xntlHOLYgWO3HAHnAGIXnrPcoRm6hK0l52AuDa81g82YpfpgMpCNUU7eJw3K3RUQA==",
+      "version": "2026.618.0",
+      "resolved": "https://registry.npmjs.org/@paperclipai/shared/-/shared-2026.618.0.tgz",
+      "integrity": "sha512-DqfQLUiWHhYRXFtMpPCeXpB+21obNYFnqcr4bEPdRrA83l5YS/SolsqfnHu8Mj65iiSrHGhQGGc7q4kvQkV2qw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "@paperclipai/shared": "*"
   },
   "devDependencies": {
-    "@paperclipai/plugin-sdk": "^2026.318.0",
-    "@paperclipai/shared": "^2026.318.0",
+    "@paperclipai/plugin-sdk": "^2026.618.0",
+    "@paperclipai/shared": "^2026.618.0",
     "@types/node": "^25.5.2",
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,5 @@
 export const PLUGIN_ID = "paperclip-plugin-slack";
-export const PLUGIN_VERSION = "2.0.6";
+export const PLUGIN_VERSION = "2.0.9";
 
 export const WEBHOOK_KEYS = {
   slackEvents: "slack-events",

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1274,7 +1274,7 @@ const plugin = definePlugin({
 
     slackAdapter = new SlackAdapter(ctx, token);
 
-    ctx.logger.info("Slack Chat OS plugin started (v2.0.0) - all 5 phases active");
+    ctx.logger.info("Slack Chat OS plugin started");
   },
 
   // =========================================================================


### PR DESCRIPTION
## Summary
- bump @paperclipai/plugin-sdk and @paperclipai/shared dev dependencies to 2026.618.0
- align the plugin manifest version constant with package version 2.0.9
- remove stale startup log text that still claimed v2.0.0

## Verification
- npm run typecheck
- npm test
- npm run build