### PR TITLE
fix: handle disabled secret resolution gracefully (port of telegram #66)

### DIFF
--- a/src/runtime-token.ts
+++ b/src/runtime-token.ts
@@ -1,0 +1,36 @@
+import type { PluginContext, PluginHealthDiagnostics } from "@paperclipai/plugin-sdk";
+
+export type SlackRuntimeHealth = PluginHealthDiagnostics & {
+  message?: string;
+  details?: Record<string, unknown>;
+};
+
+export const SECRET_RESOLUTION_DISABLED_MESSAGE = "Plugin secret references are disabled until company-scoped plugin config lands";
+export const SECRET_RESOLUTION_ISSUE_URL = "https://github.com/mvanhorn/paperclip-plugin-slack/issues/31";
+
+export async function resolveStartupSlackToken(
+  ctx: PluginContext,
+  tokenRef: string,
+  setHealth: (health: SlackRuntimeHealth) => void,
+): Promise<string | undefined> {
+  try {
+    const token = await ctx.secrets.resolve(tokenRef);
+    setHealth({ status: "ok" });
+    return token;
+  } catch (err) {
+    const error = String(err);
+    setHealth({
+      status: "degraded",
+      message: SECRET_RESOLUTION_DISABLED_MESSAGE,
+      details: {
+        issue: "paperclip-plugin-secret-resolution-disabled",
+        reference: SECRET_RESOLUTION_ISSUE_URL,
+      },
+    });
+    ctx.logger.error("Slack plugin cannot resolve Slack token secret; runtime features are disabled", {
+      error,
+      reference: SECRET_RESOLUTION_ISSUE_URL,
+    });
+    return undefined;
+  }
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -51,11 +51,13 @@ import {
   checkWatches,
   BUILTIN_WATCH_TEMPLATES,
 } from "./proactive-suggestions.js";
+import { resolveStartupSlackToken, type SlackRuntimeHealth } from "./runtime-token.js";
 
 let pluginCtx: PluginContext;
 let pluginToken: string;
 let pluginConfig: SlackConfig;
 let slackAdapter: SlackAdapter;
+let runtimeHealth: SlackRuntimeHealth = { status: "ok" };
 
 // --- Slack signature verification ---
 
@@ -404,7 +406,13 @@ const plugin = definePlugin({
       return;
     }
 
-    const token = await ctx.secrets.resolve(config.slackTokenRef);
+    const token = await resolveStartupSlackToken(ctx, config.slackTokenRef, (health) => {
+      runtimeHealth = health;
+    });
+    if (!token) {
+      ctx.logger.warn("Slack plugin runtime disabled because Slack token could not be resolved");
+      return;
+    }
     pluginToken = token;
 
     // Resolve Slack signing secret for webhook signature verification
@@ -1488,7 +1496,7 @@ const plugin = definePlugin({
   },
 
   async onHealth(): Promise<PluginHealthDiagnostics> {
-    return { status: "ok" };
+    return runtimeHealth;
   },
 });
 

--- a/tests/runtime-token.test.ts
+++ b/tests/runtime-token.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PluginContext } from "@paperclipai/plugin-sdk";
+import {
+  SECRET_RESOLUTION_DISABLED_MESSAGE,
+  SECRET_RESOLUTION_ISSUE_URL,
+  resolveStartupSlackToken,
+  type SlackRuntimeHealth,
+} from "../src/runtime-token.js";
+
+function makeContext(resolve: () => Promise<string>): PluginContext {
+  return {
+    secrets: { resolve },
+    logger: {
+      error: vi.fn(),
+    },
+  } as unknown as PluginContext;
+}
+
+describe("resolveStartupSlackToken", () => {
+  it("returns the resolved Slack token and marks health ok", async () => {
+    const health: SlackRuntimeHealth[] = [];
+    const ctx = makeContext(async () => "xoxb-token");
+
+    const token = await resolveStartupSlackToken(ctx, "secret-ref", (next) => health.push(next));
+
+    expect(token).toBe("xoxb-token");
+    expect(health).toEqual([{ status: "ok" }]);
+  });
+
+  it("degrades health and does not throw when Paperclip secret resolution fails", async () => {
+    const health: SlackRuntimeHealth[] = [];
+    const ctx = makeContext(async () => {
+      throw new Error(SECRET_RESOLUTION_DISABLED_MESSAGE);
+    });
+
+    const token = await resolveStartupSlackToken(ctx, "secret-ref", (next) => health.push(next));
+
+    expect(token).toBeUndefined();
+    expect(health).toEqual([{
+      status: "degraded",
+      message: SECRET_RESOLUTION_DISABLED_MESSAGE,
+      details: {
+        issue: "paperclip-plugin-secret-resolution-disabled",
+        reference: SECRET_RESOLUTION_ISSUE_URL,
+      },
+    }]);
+    expect(ctx.logger.error).toHaveBeenCalledWith(
+      "Slack plugin cannot resolve Slack token secret; runtime features are disabled",
+      {
+        error: `Error: ${SECRET_RESOLUTION_DISABLED_MESSAGE}`,
+        reference: SECRET_RESOLUTION_ISSUE_URL,
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Problem

On Paperclip hosts v2026.512.0 and later, this plugin cannot activate at all — worker initialization dies with `Invalid secret reference` / `Plugin secret references are disabled...`. Tracked in #31.

## Root cause

The host's secret resolver fails closed since paperclipai/paperclip#5429 (`plugin-secrets-handler.ts` throws unconditionally, pending company-scoped plugin config — fix tracked upstream in paperclipai/paperclip#6148 / #6173). Our worker resolved `slackTokenRef` unguarded at activation, so the throw propagated and the plugin landed in `error` state. (The optional `slackSigningSecretRef` resolve was already guarded.)

## Fix

Direct port of the pattern merged in mvanhorn/paperclip-plugin-telegram#66:

- New `src/runtime-token.ts` — `resolveStartupSlackToken()` catches the resolve failure, flips module health to `degraded` with a machine-readable `details.issue` and a pointer to #31, and logs the cause.
- `setup()` returns early instead of crashing when the token cannot be resolved.
- `onHealth()` now reports the runtime health instead of a hardcoded `ok`.

Behavior on healthy hosts is unchanged (`status: "ok"`, token resolved as before). On affected hosts the plugin activates inert and tells the operator why — it does not restore functionality; that requires the upstream fix.

Note for #29: this touches the same `setup()` token-resolution block Socket Mode builds on — whichever lands second rebases trivially (the guard is ~8 lines at the resolve site).

## Verification

No CI on this repo — local gate: `npm ci && npm run typecheck && npm run test` → tsc clean, **110/110 tests passing (9 files)**, including 2 new tests pinning the ok and degraded paths of `resolveStartupSlackToken`.

---
<sub><em>**[@superbiche](https://github.com/superbiche)** · co-maintainer · drafted with Claude Fable 5.</em></sub>

https://claude.ai/code/session_014EtUqWXNruHzvyfeoajMpR
