### PR TITLE
Company-scoping: deliveries-only runtime bootstrap (closes #31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,9 @@ curl -X POST http://127.0.0.1:3100/api/plugins/install \
   -d '{"packageName":"paperclip-plugin-slack"}'
 ```
 
-> [!WARNING]
-> **`paperclipai` master, post [#5429](https://github.com/paperclipai/paperclip/pull/5429) (2026-05-09):**
-> The new Secrets Manager ships with a temporary kill switch on plugin secret-ref UUIDs while a company-scoped `plugin_config` follow-up lands. If you're running paperclipai master, plugin activation will fail with `Plugin secret references are disabled until company-scoped plugin config lands`, and `POST /api/plugins/:id/config` returns HTTP 422 for configs containing secret-ref UUIDs (e.g. `slackTokenRef`). This is intentional fail-closed mitigation (PAP-2394 — see the [upstream plan doc](https://github.com/paperclipai/paperclip/blob/master/doc/plans/2026-04-26-plugin-secret-ref-company-scope.md)). Until the follow-up lands, pin to the last paperclipai release before #5429. This callout will be removed once secret-ref resolution is restored.
+> [!NOTE]
+> **Company-scoped activation ([#9557](https://github.com/paperclipai/paperclip/pull/9557), first stable in `v2026.720.0`):**
+> the host now resolves plugin secret references under a company scope. This plugin is **deliveries-only**: it reads no configuration and resolves no secrets at startup, and builds its runtime from the host's company-scoped configuration delivery (`onConfigChanged`). On **`v2026.817.0`+** it activates out of the box; on **`v2026.720.0` / `722.0`** save the plugin configuration once through the settings panel after installing, to trigger the first delivery. The earlier temporary secret-ref kill switch ([#5429](https://github.com/paperclipai/paperclip/pull/5429)) was removed upstream in #9557 — no host pinning is needed any more.
 
 ## Troubleshooting: confirm your Paperclip host
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "2.0.10",
       "license": "MIT",
       "devDependencies": {
-        "@paperclipai/plugin-sdk": "^2026.618.0",
-        "@paperclipai/shared": "^2026.618.0",
+        "@paperclipai/plugin-sdk": "^2026.817.0",
+        "@paperclipai/shared": "^2026.817.0",
         "@types/node": "^25.5.2",
         "typescript": "^5.7.0",
         "vitest": "^3.2.6"
@@ -470,13 +470,13 @@
       "license": "MIT"
     },
     "node_modules/@paperclipai/plugin-sdk": {
-      "version": "2026.618.0",
-      "resolved": "https://registry.npmjs.org/@paperclipai/plugin-sdk/-/plugin-sdk-2026.618.0.tgz",
-      "integrity": "sha512-/8hoPh4x70/1HoaAe8Hofej1Ww5RLpMfbQb8fiXpRcLY9MkEN7XjzR0jVqTw4y2bwed+xQRhPJ5QRcviM/lPkA==",
+      "version": "2026.817.0",
+      "resolved": "https://registry.npmjs.org/@paperclipai/plugin-sdk/-/plugin-sdk-2026.817.0.tgz",
+      "integrity": "sha512-2rUxMmP019009OhSZuoYxM/TXIPrnyZt5aIhmh2/ZeJ/axMvjaWpBJvxxqlvCOJ7BWb0mxx9C5qBAcgD0cAlCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@paperclipai/shared": "2026.618.0",
+        "@paperclipai/shared": "2026.817.0",
         "zod": "^3.24.2"
       },
       "bin": {
@@ -492,9 +492,9 @@
       }
     },
     "node_modules/@paperclipai/shared": {
-      "version": "2026.618.0",
-      "resolved": "https://registry.npmjs.org/@paperclipai/shared/-/shared-2026.618.0.tgz",
-      "integrity": "sha512-DqfQLUiWHhYRXFtMpPCeXpB+21obNYFnqcr4bEPdRrA83l5YS/SolsqfnHu8Mj65iiSrHGhQGGc7q4kvQkV2qw==",
+      "version": "2026.817.0",
+      "resolved": "https://registry.npmjs.org/@paperclipai/shared/-/shared-2026.817.0.tgz",
+      "integrity": "sha512-PtZJjZe3l0THbbTi+gv7eCX4H04Ul4N0gPM9BdKiowCypTAMsa6E8uyvugegFEdWC6PdN51abSY5P4utxA2Lbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "@paperclipai/shared": "*"
   },
   "devDependencies": {
-    "@paperclipai/plugin-sdk": "^2026.618.0",
-    "@paperclipai/shared": "^2026.618.0",
+    "@paperclipai/plugin-sdk": "^2026.817.0",
+    "@paperclipai/shared": "^2026.817.0",
     "@types/node": "^25.5.2",
     "typescript": "^5.7.0",
     "vitest": "^3.2.6"

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -44,16 +44,21 @@ const manifest: PaperclipPluginManifestV1 = {
   },
   instanceConfigSchema: {
     type: "object",
+    additionalProperties: true,
     properties: {
       slackTokenRef: {
-        type: "string",
+        // string | object: older hosts persist a bare secret UUID string,
+        // current hosts bind an object `{ type: "secret_ref", secretId, version? }`
+        // and reject the bare string. Declaring only "string" makes the two
+        // mutually unsatisfiable, so the plugin becomes unconfigurable on one.
+        type: ["string", "object"],
         format: "secret-ref",
         title: "Slack Bot Token (secret reference)",
         description: "Secret UUID for your Slack Bot OAuth token. Create the secret in Settings → Secrets, then paste its UUID here.",
         default: DEFAULT_CONFIG.slackTokenRef,
       },
       slackSigningSecretRef: {
-        type: "string",
+        type: ["string", "object"],
         format: "secret-ref",
         title: "Slack Signing Secret (secret reference)",
         description: "Secret UUID for your Slack app's Signing Secret. Required to verify that incoming webhooks are genuinely from Slack.",

--- a/src/proactive-suggestions.ts
+++ b/src/proactive-suggestions.ts
@@ -45,9 +45,14 @@ export async function registerWatch(
   return entry;
 }
 
-export async function removeWatch(ctx: PluginContext, watchId: string): Promise<boolean> {
+export async function removeWatch(ctx: PluginContext, watchId: string, companyId?: string): Promise<boolean> {
   const watches = await getAllWatches(ctx);
-  const filtered = watches.filter((w) => w.id !== watchId);
+  // The registry is instance-global, so a delete must be scoped to the caller's
+  // company: only remove the watch when the id matches AND (when a company is
+  // supplied) it belongs to that company. Prevents one tenant deleting another's.
+  const filtered = watches.filter(
+    (w) => !(w.id === watchId && (companyId === undefined || w.companyId === companyId)),
+  );
   if (filtered.length === watches.length) return false;
   await setAllWatches(ctx, filtered);
   return true;

--- a/src/runtime-token.ts
+++ b/src/runtime-token.ts
@@ -1,30 +1,45 @@
 import type { PluginContext, PluginHealthDiagnostics } from "@paperclipai/plugin-sdk";
+import { normalizeSecretRef } from "./secret-ref-validation.js";
 
 export type SlackRuntimeHealth = PluginHealthDiagnostics & {
   message?: string;
   details?: Record<string, unknown>;
 };
 
-export const SECRET_RESOLUTION_DISABLED_MESSAGE = "Plugin secret references are disabled until company-scoped plugin config lands";
 export const SECRET_RESOLUTION_ISSUE_URL = "https://github.com/mvanhorn/paperclip-plugin-slack/issues/31";
 
+/**
+ * Resolve the Slack bot token secret for a company-scoped configuration
+ * delivery.
+ *
+ * Called from `onConfigChanged`, never from `setup()` — an unscoped
+ * `ctx.secrets.resolve()` throws "company context is required" on governed
+ * hosts (paperclipai/paperclip#9557), so this must always run with the
+ * companyId the delivery was attributed to.
+ */
 export async function resolveStartupSlackToken(
   ctx: PluginContext,
-  tokenRef: string,
+  tokenRef: unknown,
   setHealth: (health: SlackRuntimeHealth) => void,
+  companyId?: string,
 ): Promise<string | undefined> {
   try {
-    const token = await ctx.secrets.resolve(tokenRef);
+    const normalizedRef = normalizeSecretRef(tokenRef) ?? tokenRef;
+    const token = await ctx.secrets.resolve(normalizedRef as string, {
+      companyId,
+      configPath: "slackTokenRef",
+    });
     setHealth({ status: "ok" });
     return token;
   } catch (err) {
     const error = String(err);
     setHealth({
       status: "degraded",
-      message: SECRET_RESOLUTION_DISABLED_MESSAGE,
+      message: `Slack bot token secret resolution failed: ${error}`,
       details: {
-        issue: "paperclip-plugin-secret-resolution-disabled",
+        issue: "slack-bot-token-resolution-failed",
         reference: SECRET_RESOLUTION_ISSUE_URL,
+        error,
       },
     });
     ctx.logger.error("Slack plugin cannot resolve Slack token secret; runtime features are disabled", {

--- a/src/runtime-token.ts
+++ b/src/runtime-token.ts
@@ -1,5 +1,5 @@
 import type { PluginContext, PluginHealthDiagnostics } from "@paperclipai/plugin-sdk";
-import { normalizeSecretRef } from "./secret-ref-validation.js";
+import { normalizeSecretRef, redactSecretRefs } from "./secret-ref-validation.js";
 
 export type SlackRuntimeHealth = PluginHealthDiagnostics & {
   message?: string;
@@ -32,7 +32,7 @@ export async function resolveStartupSlackToken(
     setHealth({ status: "ok" });
     return token;
   } catch (err) {
-    const error = String(err);
+    const error = redactSecretRefs(String(err), tokenRef);
     setHealth({
       status: "degraded",
       message: `Slack bot token secret resolution failed: ${error}`,

--- a/src/secret-ref-validation.ts
+++ b/src/secret-ref-validation.ts
@@ -81,9 +81,30 @@ function describeBadValue(value: unknown): string {
   if (typeof value !== "string") return `<${typeof value}>`;
   const trimmed = value.trim();
   if (trimmed.length === 0) return "<empty string>";
-  // Truncate to avoid leaking long pasted secrets into error logs.
-  const sample = trimmed.length > 16 ? `${trimmed.slice(0, 12)}…` : trimmed;
-  return `"${sample}"`;
+  // Never echo any characters of the supplied value: an operator may paste a
+  // raw Slack token here, and even a prefix in an error log is a leak.
+  return `<non-UUID string, length ${trimmed.length}>`;
+}
+
+/**
+ * Strip any occurrence of the given secret references out of a message before
+ * it is logged or published to health. The governed host interpolates the ref
+ * it rejected into its error text, so a resolver error can otherwise carry the
+ * supplied secretId (or a raw pasted value) into durable diagnostics.
+ */
+export function redactSecretRefs(message: string, ...refs: unknown[]): string {
+  let out = message;
+  for (const ref of refs) {
+    const id = normalizeSecretRefId(ref);
+    if (id) out = out.split(id).join("[redacted]");
+    if (ref && typeof ref === "object") {
+      out = out.split(JSON.stringify(ref)).join("[redacted]");
+    } else if (typeof ref === "string") {
+      const trimmed = ref.trim();
+      if (trimmed.length >= 6) out = out.split(trimmed).join("[redacted]");
+    }
+  }
+  return out;
 }
 
 function fieldError(key: string, value: unknown): string {

--- a/src/secret-ref-validation.ts
+++ b/src/secret-ref-validation.ts
@@ -1,0 +1,118 @@
+export type SecretRefConfig = {
+  slackTokenRef?: unknown;
+  slackSigningSecretRef?: unknown;
+};
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const FIELDS = [
+  { key: "slackTokenRef", required: true },
+  { key: "slackSigningSecretRef", required: true },
+] as const;
+
+/**
+ * A secret reference, in either shape a Paperclip host may use.
+ *
+ * Older hosts take a bare secret UUID string. Current hosts require an object
+ * `{ type: "secret_ref", secretId, version? }` and reject the bare string, so
+ * both must be accepted or the plugin is unconfigurable on one of them.
+ */
+export type SecretRef = string | { type: "secret_ref"; secretId: string; version?: number };
+
+export function isValidSecretRef(value: unknown): value is SecretRef {
+  if (typeof value === "string") return UUID_RE.test(value.trim());
+  if (typeof value === "object" && value !== null) {
+    const record = value as { type?: unknown; secretId?: unknown };
+    return (
+      record.type === "secret_ref" &&
+      typeof record.secretId === "string" &&
+      UUID_RE.test(record.secretId.trim())
+    );
+  }
+  return false;
+}
+
+/**
+ * Coerce a secret ref into the shape THIS host accepts before calling
+ * ctx.secrets.resolve().
+ *
+ * Refs reach us in both shapes: config validated by a current host holds
+ * `{ type: "secret_ref", secretId }`, while refs persisted by an older host
+ * hold a bare UUID string. Hosts that require the object form reject the bare
+ * string with "Invalid secret reference for plugin: <uuid>. Use
+ * { type: "secret_ref" ... }", which surfaces to the user as an unexplained
+ * 403 from whatever the token was needed for.
+ *
+ * Passing the object through unchanged keeps older hosts working, since they
+ * accept it as an opaque ref.
+ */
+export function normalizeSecretRef(value: unknown): SecretRef | null {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return UUID_RE.test(trimmed) ? { type: "secret_ref", secretId: trimmed } : null;
+  }
+  return isValidSecretRef(value) ? value : null;
+}
+
+/** The bare secret UUID a ref points at, in either shape, or null. */
+export function normalizeSecretRefId(value: unknown): string | null {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return UUID_RE.test(trimmed) ? trimmed : null;
+  }
+  if (typeof value === "object" && value !== null) {
+    const record = value as { type?: unknown; secretId?: unknown };
+    if (record.type === "secret_ref" && typeof record.secretId === "string") {
+      const trimmed = record.secretId.trim();
+      return UUID_RE.test(trimmed) ? trimmed : null;
+    }
+  }
+  return null;
+}
+
+/** True when the config value can actually be handed to ctx.secrets.resolve. */
+export function isUsableSecretRef(value: unknown): boolean {
+  return normalizeSecretRef(value) !== null;
+}
+
+function describeBadValue(value: unknown): string {
+  if (value === undefined || value === null) return "<empty>";
+  if (typeof value === "object") return "<object>";
+  if (typeof value !== "string") return `<${typeof value}>`;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return "<empty string>";
+  // Truncate to avoid leaking long pasted secrets into error logs.
+  const sample = trimmed.length > 16 ? `${trimmed.slice(0, 12)}…` : trimmed;
+  return `"${sample}"`;
+}
+
+function fieldError(key: string, value: unknown): string {
+  return [
+    `${key} must be the UUID of a Paperclip secret`,
+    `(format 8-4-4-4-12, e.g. "12f7ed4a-1234-4d0c-9abc-bd58d44d15e1").`,
+    `Got ${describeBadValue(value)}.`,
+    `Create the secret first via Settings → Secrets and paste the returned "id" value here —`,
+    `not the raw token, the whole JSON response, or any other identifier.`,
+  ].join(" ");
+}
+
+export function validateSecretRefFields(config: SecretRefConfig): string[] {
+  const errors: string[] = [];
+  for (const { key, required } of FIELDS) {
+    const value = config[key];
+    const isMissing =
+      value === undefined ||
+      value === null ||
+      (typeof value === "string" && value.trim().length === 0);
+
+    if (isMissing) {
+      if (required) errors.push(`${key} is required.`);
+      continue;
+    }
+
+    if (!isValidSecretRef(value)) {
+      errors.push(fieldError(key, value));
+    }
+  }
+  return errors;
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -212,6 +212,11 @@ function claimOwnership(ctx: PluginContext, companyId: string, config: unknown):
         "matching the host's single-tenant rule",
       { previousCompanyId: ownerCompanyId, companyId },
     );
+    // Retire the outgoing owner's runtime FIRST. Everything after can fail (the
+    // new owner may have no resolvable token), and a live runtime bound to a
+    // company that no longer owns the install is worse than none: a no-arg
+    // ensureRuntime() during the bootstrap window would otherwise still serve it.
+    runtime = null;
     ownerCompanyId = companyId;
     ownerConfigJson = configJson;
     refusedCompanies.delete(companyId);
@@ -313,6 +318,9 @@ async function bootstrapRuntime(
 ): Promise<SlackRuntime | null> {
   if (!claimOwnership(ctx, companyId, rawConfig)) return runtime;
 
+  // A failed (re-)bootstrap leaves any EXISTING runtime intact: an owner whose
+  // new save has a broken token keeps serving on the old one, degraded-but-live,
+  // until a valid save arrives. On a fresh install `runtime` is already null.
   const config = {
     ...DEFAULT_CONFIG,
     ...(rawConfig as Record<string, unknown>),
@@ -328,7 +336,6 @@ async function bootstrapRuntime(
       { companyId },
     );
     ctx.logger.warn("Slack plugin config has no resolvable bot token reference", { companyId });
-    runtime = null;
     return null;
   }
 
@@ -339,7 +346,6 @@ async function bootstrapRuntime(
   const token = await resolveStartupSlackToken(ctx, config.slackTokenRef, setRuntimeHealth, companyId);
   if (!token) {
     ctx.logger.warn("Slack plugin runtime disabled because Slack token could not be resolved", { companyId });
-    runtime = null;
     return null;
   }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -53,7 +53,9 @@ import {
 import { resolveStartupSlackToken, SECRET_RESOLUTION_ISSUE_URL, type SlackRuntimeHealth } from "./runtime-token.js";
 import {
   isUsableSecretRef,
+  normalizeSecretRef,
   normalizeSecretRefId,
+  redactSecretRefs,
   validateSecretRefFields,
 } from "./secret-ref-validation.js";
 
@@ -339,28 +341,27 @@ async function bootstrapRuntime(
     return null;
   }
 
-  if (config.paperclipBaseUrl) {
-    setBaseUrl(config.paperclipBaseUrl);
-  }
-
   const token = await resolveStartupSlackToken(ctx, config.slackTokenRef, setRuntimeHealth, companyId);
   if (!token) {
     ctx.logger.warn("Slack plugin runtime disabled because Slack token could not be resolved", { companyId });
     return null;
   }
 
-  // Signing secret is optional at resolution time: without it webhook signatures
-  // cannot be verified, so onWebhook fails closed until it resolves.
+  // Signing secret is required for inbound webhook verification. Normalize a
+  // legacy bare-UUID ref before resolving (the token path does the same) — a
+  // current host rejects a raw string ref outright (F4). onWebhook fails closed
+  // until it resolves.
   let signingSecret: string | null = null;
   if (isUsableSecretRef(config.slackSigningSecretRef)) {
     try {
-      signingSecret = await ctx.secrets.resolve(config.slackSigningSecretRef as string, {
+      const signingRef = normalizeSecretRef(config.slackSigningSecretRef) ?? config.slackSigningSecretRef;
+      signingSecret = await ctx.secrets.resolve(signingRef as string, {
         companyId,
         configPath: "slackSigningSecretRef",
       });
     } catch (err) {
-      ctx.logger.warn("Slack signing secret could not be resolved — webhook signature verification disabled", {
-        error: String(err),
+      ctx.logger.warn("Slack signing secret could not be resolved — inbound webhook verification is disabled", {
+        error: redactSecretRefs(String(err), config.slackSigningSecretRef),
         companyId,
       });
     }
@@ -374,11 +375,26 @@ async function bootstrapRuntime(
     baseUrl: config.paperclipBaseUrl || "http://localhost:3100",
   };
 
-  // Publish, then update the legacy mirrors the module-level handlers read.
+  // Publish as one coherent snapshot, THEN apply the formatter-global side
+  // effect and update the legacy mirrors the module-level handlers read. Doing
+  // setBaseUrl only here keeps a failed refresh from mutating global state the
+  // retained old runtime would be inconsistent with (F6).
   runtime = rt;
+  if (config.paperclipBaseUrl) setBaseUrl(config.paperclipBaseUrl);
   pluginToken = token;
   pluginConfig = config;
   slackSigningSecret = signingSecret;
+
+  if (!signingSecret) {
+    // Outbound works, but every inbound webhook fails closed without the signing
+    // secret. Report that honestly instead of leaving health "ok" (F4).
+    degradeHealth(
+      "Slack bot token resolved, but the signing secret is unavailable — inbound webhooks " +
+        "(events, slash commands, interactivity) are rejected until it resolves.",
+      "slack-signing-secret-unresolved",
+      { companyId },
+    );
+  }
 
   ctx.logger.info("Slack plugin runtime bootstrapped from delivered configuration", { companyId });
   return rt;
@@ -1052,11 +1068,11 @@ const plugin = definePlugin({
           required: ["watchId"],
         },
       },
-      async (params: unknown, _runCtx) => {
+      async (params: unknown, runCtx) => {
         const p = params as Record<string, unknown>;
-        const rt = ensureRuntime();
+        const rt = ensureRuntime(runCtx.companyId);
         if (!rt) return { error: "Slack plugin is not configured yet" };
-        const removed = await removeWatch(ctx, String(p.watchId));
+        const removed = await removeWatch(ctx, String(p.watchId), runCtx.companyId);
         return { content: JSON.stringify({ removed, watchId: String(p.watchId) }) };
       },
     );
@@ -1071,7 +1087,9 @@ const plugin = definePlugin({
           properties: {},
         },
       },
-      async (_params, _runCtx) => {
+      async (_params, runCtx) => {
+        const rt = ensureRuntime(runCtx.companyId);
+        if (!rt) return { error: "Slack plugin is not configured yet" };
         const templates = BUILTIN_WATCH_TEMPLATES.map((t) => ({
           name: t.name,
           eventPattern: t.eventPattern,
@@ -1267,7 +1285,10 @@ const plugin = definePlugin({
       ctx.jobs.register("daily-digest", async () => {
         const rt = ensureRuntime();
         if (!rt || !rt.config.enableDailyDigest) return;
-        const companies = await ctx.companies.list({ limit: 100, offset: 0 });
+        // Single-tenant: this worker serves only its owner. Iterating every
+        // visible company would read their data and post it with the OWNER's
+        // token/config (F2). Operate strictly on rt.companyId.
+        const companies = [{ id: rt.companyId }];
         for (const company of companies) {
           const channelId = await resolveChannel(ctx, company.id, rt.config.defaultChannelId);
           if (!channelId) continue;
@@ -1377,7 +1398,10 @@ const plugin = definePlugin({
     ctx.jobs.register("check-escalation-timeouts", async () => {
       const rt = ensureRuntime();
       if (!rt) return;
-      const companies = await ctx.companies.list({ limit: 100, offset: 0 });
+      // Single-tenant: this worker serves only its owner. Iterating every
+      // visible company would read their data and post it with the OWNER's
+      // token/config (F2). Operate strictly on rt.companyId.
+      const companies = [{ id: rt.companyId }];
       const timeoutMs = rt.config.escalationTimeoutMs ?? 900000;
       const now = Date.now();
 
@@ -1445,7 +1469,10 @@ const plugin = definePlugin({
     ctx.jobs.register("check-watches", async () => {
       const rt = ensureRuntime();
       if (!rt) return;
-      const companies = await ctx.companies.list({ limit: 100, offset: 0 });
+      // Single-tenant: this worker serves only its owner. Iterating every
+      // visible company would read their data and post it with the OWNER's
+      // token/config (F2). Operate strictly on rt.companyId.
+      const companies = [{ id: rt.companyId }];
       for (const company of companies) {
         // Get recent events from state (populated by event listeners below)
         const recentEventsRaw = await ctx.state.get({
@@ -1687,7 +1714,12 @@ const plugin = definePlugin({
   async onWebhook(input: PluginWebhookInput): Promise<void> {
     // Verify Slack request signature (skip for url_verification challenge)
     const body = input.parsedBody as Record<string, unknown> | undefined;
-    const isVerificationChallenge = body?.type === "url_verification";
+    // Scope the signature exemption to a url_verification body on the Events
+    // endpoint ONLY. Otherwise an attacker sends a slash-command / interactivity
+    // request whose parsed body carries type=url_verification and skips
+    // signature verification entirely (F1).
+    const isVerificationChallenge =
+      input.endpointKey === WEBHOOK_KEYS.slackEvents && body?.type === "url_verification";
 
     const rt = ensureRuntime();
     if (!rt) {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -7,11 +7,10 @@ import {
   type PluginWebhookInput,
   type PluginHealthDiagnostics,
 } from "@paperclipai/plugin-sdk";
-import { WEBHOOK_KEYS, STATE_KEYS, PLUGIN_ID } from "./constants.js";
+import { WEBHOOK_KEYS, STATE_KEYS, PLUGIN_ID, DEFAULT_CONFIG } from "./constants.js";
 import { postMessage, respondToAction, respondEphemeral } from "./slack-api.js";
 import type { SlackMessage } from "./slack-api.js";
 import type { SlackConfig, EscalationRecord, CommandDefinition, SessionEntry } from "./types.js";
-import { SlackAdapter } from "./adapter.js";
 import {
   spawnAgent,
   closeAgent,
@@ -51,23 +50,341 @@ import {
   checkWatches,
   BUILTIN_WATCH_TEMPLATES,
 } from "./proactive-suggestions.js";
-import { resolveStartupSlackToken, type SlackRuntimeHealth } from "./runtime-token.js";
+import { resolveStartupSlackToken, SECRET_RESOLUTION_ISSUE_URL, type SlackRuntimeHealth } from "./runtime-token.js";
+import {
+  isUsableSecretRef,
+  normalizeSecretRefId,
+  validateSecretRefFields,
+} from "./secret-ref-validation.js";
 
+// =========================================================================
+// Runtime state — deliveries-only company scoping
+//
+// setup() runs OUTSIDE any company scope. Since paperclipai/paperclip#9557 the
+// SDK's governed gate requires a company scope for `config.get()` and
+// `secrets.resolve()`; an unscoped call in setup() throws "company context is
+// required" and kills activation (issue #31). So setup() only registers
+// handlers, and `onConfigChanged` is the ONLY thing that builds/refreshes the
+// runtime — resolving secrets under the company the host attributed the
+// delivery to. Handlers no-op until a delivery has built the runtime.
+// =========================================================================
+
+/** Everything a company-scoped invocation needs, built from a config delivery. */
+type SlackRuntime = {
+  companyId: string;
+  config: SlackConfig;
+  token: string;
+  signingSecret: string | null;
+  baseUrl: string;
+};
+
+/** Captured in setup() so onWebhook / onConfigChanged can reach the host APIs. */
 let pluginCtx: PluginContext;
+/** The active runtime, or null until the first configuration delivery. */
+let runtime: SlackRuntime | null = null;
+let runtimeHealth: SlackRuntimeHealth = {
+  status: "degraded",
+  message: "Waiting for company-scoped configuration from the host",
+  details: {
+    issue: "slack-awaiting-company-config",
+    reference: SECRET_RESOLUTION_ISSUE_URL,
+  },
+};
+
+// Legacy convenience mirrors, written only by bootstrapRuntime. Module-level
+// handlers (slash commands, interactivity) read these AFTER an ensureRuntime()
+// guard upstream has confirmed the runtime exists.
 let pluginToken: string;
 let pluginConfig: SlackConfig;
-let slackAdapter: SlackAdapter;
-let runtimeHealth: SlackRuntimeHealth = { status: "ok" };
+let slackSigningSecret: string | null = null;
+
+/**
+ * The single ordered critical section every configuration delivery runs inside.
+ * Host->worker requests are NOT serialized by the transport, so two deliveries
+ * must queue against each other here.
+ */
+let bootstrapQueue: Promise<void> = Promise.resolve();
+/** The company this worker serves, once one has been selected. */
+let ownerCompanyId: string | null = null;
+/** Config last accepted for the owner, for the host's equal-config rule. */
+let ownerConfigJson: string | null = null;
+/** Companies already refused; keeps a chatty non-owner from flooding the log. */
+const refusedCompanies = new Set<string>();
+
+function setRuntimeHealth(health: SlackRuntimeHealth): void {
+  runtimeHealth = health;
+}
+
+function degradeHealth(message: string, issue: string, details?: Record<string, unknown>): void {
+  runtimeHealth = {
+    status: "degraded",
+    message,
+    details: { issue, reference: SECRET_RESOLUTION_ISSUE_URL, ...details },
+  };
+}
+
+/** Test seam — reset all module-level runtime state. */
+export function _resetRuntimeForTests(): void {
+  runtime = null;
+  bootstrapQueue = Promise.resolve();
+  ownerCompanyId = null;
+  ownerConfigJson = null;
+  refusedCompanies.clear();
+  pluginToken = undefined as unknown as string;
+  pluginConfig = undefined as unknown as SlackConfig;
+  slackSigningSecret = null;
+  runtimeHealth = {
+    status: "degraded",
+    message: "Waiting for company-scoped configuration from the host",
+    details: {
+      issue: "slack-awaiting-company-config",
+      reference: SECRET_RESOLUTION_ISSUE_URL,
+    },
+  };
+}
+
+/** Current runtime, or null when the plugin has not been bootstrapped yet. */
+export function _getRuntimeForTests(): SlackRuntime | null {
+  return runtime;
+}
+
+/**
+ * The runtime for a company-scoped invocation, or null.
+ *
+ * Never reads config and never bootstraps: configuration deliveries are the
+ * ONLY way a runtime starts. A company that is not the owner gets null, logged
+ * once. Callers MUST treat null as "do nothing for this company".
+ */
+function ensureRuntime(companyId?: string | null): SlackRuntime | null {
+  if (companyId && ownerCompanyId && companyId !== ownerCompanyId) {
+    if (pluginCtx && !refusedCompanies.has(companyId)) {
+      refusedCompanies.add(companyId);
+      pluginCtx.logger.warn(
+        `Slack plugin ignoring an invocation for company ${companyId}; this install serves ${ownerCompanyId}`,
+        { runningCompanyId: ownerCompanyId, invokingCompanyId: companyId },
+      );
+    }
+    return null;
+  }
+  if (!runtime) return null;
+  if (companyId && companyId !== runtime.companyId) return null;
+  return runtime;
+}
+
+function stableConfigJson(config: unknown): string {
+  const normalize = (value: unknown): unknown => {
+    if (Array.isArray(value)) return value.map(normalize);
+    if (value && typeof value === "object") {
+      return Object.fromEntries(
+        Object.entries(value as Record<string, unknown>)
+          .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+          .map(([key, entry]) => [key, normalize(entry)]),
+      );
+    }
+    return value;
+  };
+  return JSON.stringify(normalize(config));
+}
+
+/**
+ * The single ownership gate. The first company whose configuration reaches this
+ * worker claims it; claiming does not require the runtime to start, so an owner
+ * whose token stopped resolving stays the owner. One exception, mirroring the
+ * host's single-tenant guard: an identical configuration under a DIFFERENT
+ * company advances ownership (migration duplicates each unbound legacy config
+ * across every company), else the plugin would own A while the SDK owns B.
+ */
+function claimOwnership(ctx: PluginContext, companyId: string, config: unknown): boolean {
+  const configJson = stableConfigJson(config);
+
+  if (!ownerCompanyId) {
+    ownerCompanyId = companyId;
+    ownerConfigJson = configJson;
+    return true;
+  }
+  if (ownerCompanyId === companyId) {
+    ownerConfigJson = configJson;
+    return true;
+  }
+  if (ownerConfigJson !== null && ownerConfigJson === configJson) {
+    ctx.logger.info(
+      `Slack plugin owner advancing from company ${ownerCompanyId} to ${companyId}: identical configuration, ` +
+        "matching the host's single-tenant rule",
+      { previousCompanyId: ownerCompanyId, companyId },
+    );
+    ownerCompanyId = companyId;
+    ownerConfigJson = configJson;
+    refusedCompanies.delete(companyId);
+    return true;
+  }
+  if (!refusedCompanies.has(companyId)) {
+    refusedCompanies.add(companyId);
+    ctx.logger.warn(
+      `Slack plugin ignoring configuration for company ${companyId}; this install serves ${ownerCompanyId}`,
+      { runningCompanyId: ownerCompanyId, deliveredCompanyId: companyId },
+    );
+  }
+  return false;
+}
+
+async function readScopedConfig(
+  ctx: PluginContext,
+  companyId: string,
+): Promise<Record<string, unknown> | null> {
+  try {
+    const rawConfig = await ctx.config.get(companyId);
+    return (rawConfig as Record<string, unknown>) ?? null;
+  } catch (err) {
+    ctx.logger.debug("Company-scoped plugin config is not readable", {
+      companyId,
+      error: String(err),
+    });
+    return null;
+  }
+}
+
+/**
+ * Identify which company a context-less config delivery belongs to.
+ *
+ * The v2026.720/722 SDKs call onConfigChanged(config) with no scope, but the
+ * host still binds the invocation to the real company and denies a read for any
+ * other one, so probing each company here identifies the delivered scope: only
+ * the right company answers.
+ */
+async function identifyDeliveredCompany(
+  ctx: PluginContext,
+  deliveredConfig: unknown,
+): Promise<string | null> {
+  let companies: Array<{ id: string }>;
+  try {
+    companies = await ctx.companies.list();
+  } catch (err) {
+    ctx.logger.info("Could not list companies while attributing a configuration delivery", {
+      error: String(err),
+    });
+    return null;
+  }
+
+  const readable: Array<{ id: string; config: Record<string, unknown> }> = [];
+  for (const company of companies) {
+    const config = await readScopedConfig(ctx, company.id);
+    if (config) readable.push({ id: company.id, config });
+  }
+
+  if (readable.length === 0) return null;
+  if (readable.length === 1) return readable[0].id;
+
+  // A host that answers for several companies (>= 2026.817.0) is not telling us
+  // which one was saved; match the delivered secret reference against the rows.
+  const deliveredSecretId = normalizeSecretRefId(
+    (deliveredConfig as Record<string, unknown> | null)?.slackTokenRef,
+  );
+  if (deliveredSecretId) {
+    const match = readable.find(
+      (row) => normalizeSecretRefId(row.config.slackTokenRef) === deliveredSecretId,
+    );
+    if (match) return match.id;
+  }
+  return readable[0].id;
+}
+
+/**
+ * Run one bootstrap attempt inside the ordered critical section shared by every
+ * configuration delivery — the only thing that bootstraps.
+ */
+function queueBootstrap<T>(work: () => Promise<T>): Promise<T> {
+  const next = bootstrapQueue.then(work, work);
+  bootstrapQueue = next.then(
+    () => undefined,
+    () => undefined,
+  );
+  return next;
+}
+
+/**
+ * Apply one company's stored configuration to the runtime. Callers MUST go
+ * through queueBootstrap. Never throws: every failure path degrades health and
+ * returns null.
+ */
+async function bootstrapRuntime(
+  ctx: PluginContext,
+  companyId: string,
+  rawConfig: unknown,
+): Promise<SlackRuntime | null> {
+  if (!claimOwnership(ctx, companyId, rawConfig)) return runtime;
+
+  const config = {
+    ...DEFAULT_CONFIG,
+    ...(rawConfig as Record<string, unknown>),
+  } as unknown as SlackConfig;
+
+  // Required config is reported through health, never thrown: throwing here
+  // would kill worker activation on a host that simply has not delivered a
+  // usable config yet. onValidateConfig is what fails a bad save loudly.
+  if (!isUsableSecretRef(config.slackTokenRef)) {
+    degradeHealth(
+      `[${PLUGIN_ID}] slackTokenRef is missing or not a Paperclip secret UUID; set the Slack bot token in plugin settings`,
+      "slack-bot-token-missing",
+      { companyId },
+    );
+    ctx.logger.warn("Slack plugin config has no resolvable bot token reference", { companyId });
+    runtime = null;
+    return null;
+  }
+
+  if (config.paperclipBaseUrl) {
+    setBaseUrl(config.paperclipBaseUrl);
+  }
+
+  const token = await resolveStartupSlackToken(ctx, config.slackTokenRef, setRuntimeHealth, companyId);
+  if (!token) {
+    ctx.logger.warn("Slack plugin runtime disabled because Slack token could not be resolved", { companyId });
+    runtime = null;
+    return null;
+  }
+
+  // Signing secret is optional at resolution time: without it webhook signatures
+  // cannot be verified, so onWebhook fails closed until it resolves.
+  let signingSecret: string | null = null;
+  if (isUsableSecretRef(config.slackSigningSecretRef)) {
+    try {
+      signingSecret = await ctx.secrets.resolve(config.slackSigningSecretRef as string, {
+        companyId,
+        configPath: "slackSigningSecretRef",
+      });
+    } catch (err) {
+      ctx.logger.warn("Slack signing secret could not be resolved — webhook signature verification disabled", {
+        error: String(err),
+        companyId,
+      });
+    }
+  }
+
+  const rt: SlackRuntime = {
+    companyId,
+    config,
+    token,
+    signingSecret,
+    baseUrl: config.paperclipBaseUrl || "http://localhost:3100",
+  };
+
+  // Publish, then update the legacy mirrors the module-level handlers read.
+  runtime = rt;
+  pluginToken = token;
+  pluginConfig = config;
+  slackSigningSecret = signingSecret;
+
+  ctx.logger.info("Slack plugin runtime bootstrapped from delivered configuration", { companyId });
+  return rt;
+}
 
 // --- Slack signature verification ---
-
-let slackSigningSecret: string | null = null;
 
 function verifySlackSignature(
   headers: Record<string, string | string[]>,
   rawBody: string,
 ): boolean {
-  if (!slackSigningSecret) return true; // skip if not configured
+  if (!slackSigningSecret) return false; // fail closed: cannot verify without the signing secret
 
   const timestamp = String(
     headers["x-slack-request-timestamp"] ??
@@ -147,14 +464,11 @@ function genId(prefix: string): string {
 
 // --- Slash command routing ---
 
-async function handleSlashCommand(ctx: PluginContext, rawBody: string): Promise<void> {
+async function handleSlashCommand(ctx: PluginContext, rawBody: string, companyId: string): Promise<void> {
   const { text, responseUrl, channelId, threadTs } = parseSlashCommand(rawBody);
   const parts = text.trim().split(/\s+/);
   const subcommand = parts[0]?.toLowerCase() ?? "";
   const arg = parts[1]?.toLowerCase() ?? "";
-
-  const companies = await ctx.companies.list({ limit: 1, offset: 0 });
-  const companyId = companies[0]?.id ?? "";
 
   try {
     switch (subcommand) {
@@ -386,43 +700,13 @@ async function handleApproveCommand(ctx: PluginContext, responseUrl: string, app
 
 const plugin = definePlugin({
   async setup(ctx) {
-    const rawConfig = await ctx.config.get();
-    const config = rawConfig as unknown as SlackConfig;
-    // Always reads the current persisted config so flag changes (e.g.
-    // toggling notifyOnAgentConnected) take effect without restarting the
-    // plugin worker.
-    const getConfig = async (): Promise<SlackConfig> =>
-      (await ctx.config.get()) as unknown as SlackConfig;
-
     pluginCtx = ctx;
-    pluginConfig = config;
 
-    if (config.paperclipBaseUrl) {
-      setBaseUrl(config.paperclipBaseUrl);
-    }
-
-    if (!config.slackTokenRef) {
-      ctx.logger.warn("No slackTokenRef configured, notifications disabled");
-      return;
-    }
-
-    const token = await resolveStartupSlackToken(ctx, config.slackTokenRef, (health) => {
-      runtimeHealth = health;
-    });
-    if (!token) {
-      ctx.logger.warn("Slack plugin runtime disabled because Slack token could not be resolved");
-      return;
-    }
-    pluginToken = token;
-
-    // Resolve Slack signing secret for webhook signature verification
-    if (config.slackSigningSecretRef) {
-      try {
-        slackSigningSecret = await ctx.secrets.resolve(config.slackSigningSecretRef);
-      } catch {
-        ctx.logger.warn("Slack signing secret not configured — webhook signature verification disabled");
-      }
-    }
+    // Handlers are registered unconditionally and synchronously — the SDK
+    // requires every registration to complete within setup(). The company-
+    // scoped config that used to gate them is unreadable here (it arrives only
+    // via onConfigChanged), so each handler starts with ensureRuntime() and
+    // no-ops until a configuration delivery has built the runtime.
 
     // =========================================================================
     // PHASE 1: Escalation - using 3-arg ctx.tools.register with ToolRunContext
@@ -459,6 +743,8 @@ const plugin = definePlugin({
       async (params: unknown, runCtx) => {
         const p = params as Record<string, unknown>;
         const companyId = runCtx.companyId;
+        const rt = ensureRuntime(companyId);
+        if (!rt) return { error: "Slack plugin is not configured yet" };
         const escalationId = genId("esc");
 
         const record: EscalationRecord = {
@@ -473,13 +759,13 @@ const plugin = definePlugin({
           createdAt: new Date().toISOString(),
         };
 
-        const channelId = config.escalationChatId || config.approvalsChannelId || config.defaultChannelId;
+        const channelId = rt.config.escalationChatId || rt.config.approvalsChannelId || rt.config.defaultChannelId;
         if (!channelId) {
           return { error: "No escalation channel configured" };
         }
 
         const message = formatEscalationMessage(record);
-        const result = await postMessage(ctx, token, channelId, message);
+        const result = await postMessage(ctx, rt.token, channelId, message);
 
         if (result.ok && result.ts) {
           await ctx.state.set(
@@ -503,8 +789,8 @@ const plugin = definePlugin({
           await ctx.metrics.write("slack.escalations.created", 1);
         }
 
-        if (config.escalationHoldMessage) {
-          return { content: JSON.stringify({ escalationId, holdMessage: config.escalationHoldMessage }) };
+        if (rt.config.escalationHoldMessage) {
+          return { content: JSON.stringify({ escalationId, holdMessage: rt.config.escalationHoldMessage }) };
         }
         return { content: JSON.stringify({ escalationId }) };
       },
@@ -535,6 +821,8 @@ const plugin = definePlugin({
       async (params: unknown, runCtx) => {
         const p = params as Record<string, unknown>;
         const companyId = runCtx.companyId;
+        const rt = ensureRuntime(companyId);
+        if (!rt) return { error: "Slack plugin is not configured yet" };
         const fromAgent = String(p.fromAgent ?? "");
         const toAgent = String(p.toAgent ?? "");
         const reason = String(p.reason ?? "");
@@ -561,7 +849,7 @@ const plugin = definePlugin({
         );
 
         const blocks = buildHandoffBlocks(fromAgent, toAgent, reason, handoffId);
-        await postMessage(ctx, token, channelId, {
+        await postMessage(ctx, rt.token, channelId, {
           text: `Handoff: ${fromAgent} -> ${toAgent}: ${reason}`,
           blocks,
         }, threadTs ? { threadTs } : undefined);
@@ -591,7 +879,9 @@ const plugin = definePlugin({
       async (params: unknown, runCtx) => {
         const p = params as Record<string, unknown>;
         const companyId = runCtx.companyId;
-        const result = await startDiscussion(ctx, token, companyId, {
+        const rt = ensureRuntime(companyId);
+        if (!rt) return { error: "Slack plugin is not configured yet" };
+        const result = await startDiscussion(ctx, rt.token, companyId, {
           initiatorAgent: String(p.initiatorAgent ?? ""),
           targetAgent: String(p.targetAgent ?? ""),
           topic: String(p.topic ?? ""),
@@ -625,9 +915,11 @@ const plugin = definePlugin({
       },
       async (params: unknown, runCtx) => {
         const p = params as Record<string, unknown>;
+        const rt = ensureRuntime(runCtx.companyId);
+        if (!rt) return { error: "Slack plugin is not configured yet" };
         const result = await processMediaFile(
           ctx,
-          token,
+          rt.token,
           runCtx.companyId,
           String(p.fileId),
           String(p.channelId),
@@ -683,6 +975,8 @@ const plugin = definePlugin({
       },
       async (params: unknown, runCtx) => {
         const p = params as Record<string, unknown>;
+        const rt = ensureRuntime(runCtx.companyId);
+        if (!rt) return { error: "Slack plugin is not configured yet" };
         const command: CommandDefinition = {
           name: String(p.name),
           description: String(p.description),
@@ -724,6 +1018,8 @@ const plugin = definePlugin({
       },
       async (params: unknown, runCtx) => {
         const p = params as Record<string, unknown>;
+        const rt = ensureRuntime(runCtx.companyId);
+        if (!rt) return { error: "Slack plugin is not configured yet" };
         const watch = await registerWatch(ctx, runCtx.companyId, {
           channelId: String(p.channelId),
           threadTs: String(p.threadTs ?? ""),
@@ -752,6 +1048,8 @@ const plugin = definePlugin({
       },
       async (params: unknown, _runCtx) => {
         const p = params as Record<string, unknown>;
+        const rt = ensureRuntime();
+        if (!rt) return { error: "Slack plugin is not configured yet" };
         const removed = await removeWatch(ctx, String(p.watchId));
         return { content: JSON.stringify({ removed, watchId: String(p.watchId) }) };
       },
@@ -787,10 +1085,12 @@ const plugin = definePlugin({
       overrideChannelId?: string,
       opts?: { threadTs?: string },
     ) => {
-      const fallback = overrideChannelId || config.defaultChannelId;
+      const rt = ensureRuntime(event.companyId);
+      if (!rt) return;
+      const fallback = overrideChannelId || rt.config.defaultChannelId;
       const channelId = await resolveChannel(ctx, event.companyId, fallback);
       if (!channelId) return;
-      const result = await postMessage(ctx, token, channelId, formatter(event), opts);
+      const result = await postMessage(ctx, rt.token, channelId, formatter(event), opts);
       if (result.ok) {
         await ctx.activity.log({
           companyId: event.companyId,
@@ -812,7 +1112,9 @@ const plugin = definePlugin({
     // Handlers are always registered so that config changes (e.g. toggling
     // notifyOnAgentConnected) take effect without a plugin restart.
     ctx.events.on("issue.created", async (event: PluginEvent) => {
-      const live = await getConfig();
+      const rt = ensureRuntime(event.companyId);
+      if (!rt) return;
+      const live = rt.config;
       if (!live.notifyOnIssueCreated) return;
       const result = await notify(event, formatIssueCreated);
       if (result?.ok && result.ts) {
@@ -824,7 +1126,9 @@ const plugin = definePlugin({
     });
 
     ctx.events.on("issue.updated", async (event: PluginEvent) => {
-      const live = await getConfig();
+      const rt = ensureRuntime(event.companyId);
+      if (!rt) return;
+      const live = rt.config;
       if (!live.notifyOnIssueDone) return;
       const payload = event.payload as Record<string, unknown>;
       if (payload.status !== "done") return;
@@ -837,19 +1141,25 @@ const plugin = definePlugin({
     });
 
     ctx.events.on("approval.created", async (event: PluginEvent) => {
-      const live = await getConfig();
+      const rt = ensureRuntime(event.companyId);
+      if (!rt) return;
+      const live = rt.config;
       if (!live.notifyOnApprovalCreated) return;
       await notify(event, formatApprovalCreated, live.approvalsChannelId);
     });
 
     ctx.events.on("agent.run.failed", async (event: PluginEvent) => {
-      const live = await getConfig();
+      const rt = ensureRuntime(event.companyId);
+      if (!rt) return;
+      const live = rt.config;
       if (!live.notifyOnAgentError) return;
       await notify(event, formatAgentError, live.errorsChannelId);
     });
 
     ctx.events.on("agent.status_changed", async (event: PluginEvent) => {
-      const live = await getConfig();
+      const rt = ensureRuntime(event.companyId);
+      if (!rt) return;
+      const live = rt.config;
       if (!live.notifyOnAgentConnected) return;
       const payload = event.payload as Record<string, unknown>;
       if (payload.status === "active" || payload.status === "online") {
@@ -858,7 +1168,9 @@ const plugin = definePlugin({
     });
 
     ctx.events.on("agent.run.finished", async (event: PluginEvent) => {
-      const live = await getConfig();
+      const rt = ensureRuntime(event.companyId);
+      if (!rt) return;
+      const live = rt.config;
       if (!live.notifyOnAgentConnected) return;
       const payload = event.payload as Record<string, unknown>;
       // Dedup on agent id, not run id — event.entityId is the run UUID for
@@ -888,7 +1200,9 @@ const plugin = definePlugin({
     });
 
     ctx.events.on("cost_event.created", async (event: PluginEvent) => {
-      const live = await getConfig();
+      const rt = ensureRuntime(event.companyId);
+      if (!rt) return;
+      const live = rt.config;
       if (!live.notifyOnBudgetThreshold) return;
       const payload = event.payload as Record<string, unknown>;
       const pct = Number(payload.percentUsed ?? 0);
@@ -922,7 +1236,7 @@ const plugin = definePlugin({
         scopeId: companyId,
         stateKey: STATE_KEYS.slackChannel,
       });
-      return { channelId: saved ?? config.defaultChannelId };
+      return { channelId: saved ?? ensureRuntime(companyId)?.config.defaultChannelId ?? "" };
     });
 
     ctx.actions.register("set-channel", async (params) => {
@@ -940,12 +1254,16 @@ const plugin = definePlugin({
     // Jobs
     // =========================================================================
 
-    // Daily digest
-    if (config.enableDailyDigest) {
+    // Daily digest — always registered; the enableDailyDigest flag is checked
+    // inside each handler against the delivered runtime config, because config
+    // is not readable at setup time under company scoping.
+    {
       ctx.jobs.register("daily-digest", async () => {
+        const rt = ensureRuntime();
+        if (!rt || !rt.config.enableDailyDigest) return;
         const companies = await ctx.companies.list({ limit: 100, offset: 0 });
         for (const company of companies) {
-          const channelId = await resolveChannel(ctx, company.id, config.defaultChannelId);
+          const channelId = await resolveChannel(ctx, company.id, rt.config.defaultChannelId);
           if (!channelId) continue;
 
           const issues = await ctx.issues.list({ companyId: company.id, limit: 200, offset: 0 });
@@ -988,7 +1306,7 @@ const plugin = definePlugin({
             }
           }
 
-          await postMessage(ctx, token, channelId, formatDailyDigest({
+          await postMessage(ctx, rt.token, channelId, formatDailyDigest({
             tasksCompleted,
             tasksCreated,
             agentsActive,
@@ -1015,6 +1333,8 @@ const plugin = definePlugin({
 
       // Accumulate costs
       ctx.events.on("cost_event.created", async (event: PluginEvent) => {
+        const rt = ensureRuntime(event.companyId);
+        if (!rt || !rt.config.enableDailyDigest) return;
         const payload = event.payload as Record<string, unknown>;
         const cost = Number(payload.cost ?? 0);
         if (cost <= 0) return;
@@ -1049,8 +1369,10 @@ const plugin = definePlugin({
 
     // Escalation timeout job
     ctx.jobs.register("check-escalation-timeouts", async () => {
+      const rt = ensureRuntime();
+      if (!rt) return;
       const companies = await ctx.companies.list({ limit: 100, offset: 0 });
-      const timeoutMs = config.escalationTimeoutMs ?? 900000;
+      const timeoutMs = rt.config.escalationTimeoutMs ?? 900000;
       const now = Date.now();
 
       for (const company of companies) {
@@ -1073,7 +1395,7 @@ const plugin = definePlugin({
           if (now - createdAt < timeoutMs) continue;
 
           const escalationId = String(record.id);
-          const defaultAction = config.escalationDefaultAction ?? "defer";
+          const defaultAction = rt.config.escalationDefaultAction ?? "defer";
 
           await ctx.state.set(
             { scopeKind: "company", scopeId: company.id, stateKey: STATE_KEYS.escalationRecord(escalationId) },
@@ -1093,7 +1415,7 @@ const plugin = definePlugin({
           }) as string | null;
 
           if (channelId && threadTs) {
-            await postMessage(ctx, token, channelId, {
+            await postMessage(ctx, rt.token, channelId, {
               text: `Escalation timed out - default action: ${defaultAction}`,
               blocks: [
                 {
@@ -1115,6 +1437,8 @@ const plugin = definePlugin({
 
     // Phase 5: Check watches job
     ctx.jobs.register("check-watches", async () => {
+      const rt = ensureRuntime();
+      if (!rt) return;
       const companies = await ctx.companies.list({ limit: 100, offset: 0 });
       for (const company of companies) {
         // Get recent events from state (populated by event listeners below)
@@ -1128,7 +1452,7 @@ const plugin = definePlugin({
           : [];
 
         if (recentEvents.length > 0) {
-          await checkWatches(ctx, token, company.id, recentEvents);
+          await checkWatches(ctx, rt.token, company.id, recentEvents);
           // Clear after processing
           await ctx.state.set(
             { scopeKind: "company", scopeId: company.id, stateKey: "recent-watch-events" },
@@ -1144,8 +1468,10 @@ const plugin = definePlugin({
 
     // Native agent streaming output
     ctx.events.on("plugin.slack.agent-stream-chunk", async (event: PluginEvent) => {
+      const rt = ensureRuntime(event.companyId);
+      if (!rt) return;
       const p = event.payload as Record<string, unknown>;
-      await handleAgentOutput(ctx, token, event.companyId, {
+      await handleAgentOutput(ctx, rt.token, event.companyId, {
         channel: String(p.channel ?? ""),
         threadTs: String(p.threadTs ?? ""),
         text: String(p.text ?? ""),
@@ -1157,8 +1483,10 @@ const plugin = definePlugin({
 
     // ACP output events (from cross-plugin)
     ctx.events.on(`plugin.paperclip-plugin-acp.output`, async (event: PluginEvent) => {
+      const rt = ensureRuntime(event.companyId);
+      if (!rt) return;
       const p = event.payload as Record<string, unknown>;
-      await handleAgentOutput(ctx, token, event.companyId, {
+      await handleAgentOutput(ctx, rt.token, event.companyId, {
         channel: String(p.channel ?? ""),
         threadTs: String(p.threadTs ?? ""),
         text: String(p.text ?? ""),
@@ -1170,6 +1498,7 @@ const plugin = definePlugin({
 
     // Escalation thread reply routing (from Slack Events API)
     ctx.events.on("plugin.slack.thread_reply_escalation", async (event: PluginEvent) => {
+      if (!ensureRuntime(event.companyId)) return;
       const p = event.payload as Record<string, unknown>;
       const escalationId = String(p.escalationId ?? "");
       const replyText = String(p.text ?? "");
@@ -1218,6 +1547,8 @@ const plugin = definePlugin({
 
     // Thread message routing (multi-agent + custom commands + media)
     ctx.events.on("plugin.slack.thread_message", async (event: PluginEvent) => {
+      const rt = ensureRuntime(event.companyId);
+      if (!rt) return;
       const p = event.payload as Record<string, unknown>;
       const channel = String(p.channel ?? "");
       const threadTs = String(p.threadTs ?? "");
@@ -1231,13 +1562,13 @@ const plugin = definePlugin({
         const fileId = String(file.id ?? "");
         const mimetype = String(file.mimetype ?? "");
         if (fileId && isMediaFile(mimetype)) {
-          await processMediaFile(ctx, token, event.companyId, fileId, channel, threadTs);
+          await processMediaFile(ctx, rt.token, event.companyId, fileId, channel, threadTs);
         }
       }
 
       // Phase 4: Check for custom commands
       if (text) {
-        const handled = await tryCustomCommand(ctx, token, event.companyId, channel, threadTs, text);
+        const handled = await tryCustomCommand(ctx, rt.token, event.companyId, channel, threadTs, text);
         if (handled) return;
       }
 
@@ -1255,6 +1586,7 @@ const plugin = definePlugin({
     ];
     for (const eventType of watchableEvents) {
       ctx.events.on(eventType, async (event: PluginEvent) => {
+        if (!ensureRuntime(event.companyId)) return;
         const recentEventsRaw = await ctx.state.get({
           scopeKind: "company",
           scopeId: event.companyId,
@@ -1280,9 +1612,66 @@ const plugin = definePlugin({
       });
     }
 
-    slackAdapter = new SlackAdapter(ctx, token);
+    ctx.logger.info("Slack Chat OS plugin handlers registered; waiting for delivered configuration");
+  },
 
-    ctx.logger.info("Slack Chat OS plugin started");
+  /**
+   * The host delivers stored config here — at worker startup and on every save —
+   * and, from SDK v2026.817.0, with its company scope. Before then the config
+   * arrives with no scope; probe for the delivered company inside this
+   * invocation (only the delivered company answers a scoped config read).
+   */
+  async onConfigChanged(newConfig, context): Promise<void> {
+    const ctx = pluginCtx;
+    if (!ctx) return;
+
+    await queueBootstrap(async () => {
+      let companyId = context?.companyId ?? null;
+      if (!companyId) {
+        const running = runtime;
+        if (running) {
+          // Do NOT assume a context-less delivery belongs to the running
+          // company: probe it, and if it does not answer this delivery belongs
+          // to somebody else — leave the running company untouched.
+          const ownConfig = await readScopedConfig(ctx, running.companyId);
+          if (ownConfig) {
+            companyId = running.companyId;
+          } else {
+            const other = await identifyDeliveredCompany(ctx, newConfig);
+            ctx.logger.warn(
+              other
+                ? `Slack plugin ignoring configuration for company ${other}; this install serves ${running.companyId}`
+                : `Slack plugin ignoring a configuration delivery it could not attribute; this install serves ${running.companyId}`,
+              { runningCompanyId: running.companyId, deliveredCompanyId: other },
+            );
+            return;
+          }
+        } else {
+          companyId = await identifyDeliveredCompany(ctx, newConfig);
+        }
+
+        if (companyId) {
+          ctx.logger.info("Config delivered without a company scope; identified it by scoped probe", { companyId });
+        }
+      }
+
+      if (!companyId) {
+        degradeHealth(
+          "Configuration was delivered without a company scope and no company answered a scoped " +
+            "configuration read, so its secrets cannot be resolved. Upgrade the host to v2026.817.0 or newer.",
+          "slack-config-scope-unknown",
+        );
+        return;
+      }
+
+      try {
+        await bootstrapRuntime(ctx, companyId, newConfig);
+      } catch (err) {
+        const error = String(err);
+        ctx.logger.error("Slack plugin failed to apply a configuration change", { error, companyId });
+        degradeHealth(`Applying the delivered configuration failed: ${error}`, "slack-config-apply-failed", { companyId });
+      }
+    });
   },
 
   // =========================================================================
@@ -1293,6 +1682,15 @@ const plugin = definePlugin({
     // Verify Slack request signature (skip for url_verification challenge)
     const body = input.parsedBody as Record<string, unknown> | undefined;
     const isVerificationChallenge = body?.type === "url_verification";
+
+    const rt = ensureRuntime();
+    if (!rt) {
+      // Not bootstrapped: no signing secret to verify with and no token to act
+      // on. Only the Slack URL-verification handshake needs no runtime.
+      if (isVerificationChallenge) return;
+      pluginCtx.logger.warn("Rejecting webhook: Slack plugin is not configured yet");
+      return;
+    }
 
     if (!isVerificationChallenge && !verifySlackSignature(input.headers, input.rawBody)) {
       pluginCtx.logger.warn("Rejected webhook: invalid Slack signature");
@@ -1309,13 +1707,12 @@ const plugin = definePlugin({
       if (body?.type === "event_callback") {
         const event = body.event as Record<string, unknown> | undefined;
         if (event?.type === "file_shared") {
-          const companies = await pluginCtx.companies.list({ limit: 1, offset: 0 });
-          const companyId = companies[0]?.id ?? "";
+          const companyId = rt.companyId;
           const fileId = String(event.file_id ?? "");
           const channelId = String(event.channel_id ?? "");
 
           if (fileId && channelId) {
-            await processMediaFile(pluginCtx, pluginToken, companyId, fileId, channelId, "");
+            await processMediaFile(pluginCtx, rt.token, companyId, fileId, channelId, "");
           }
         }
       }
@@ -1323,7 +1720,7 @@ const plugin = definePlugin({
 
     // Slash commands
     if (input.endpointKey === WEBHOOK_KEYS.slashCommand) {
-      await handleSlashCommand(pluginCtx, input.rawBody);
+      await handleSlashCommand(pluginCtx, input.rawBody, rt.companyId);
       return;
     }
 
@@ -1347,8 +1744,7 @@ const plugin = definePlugin({
 
       if (!actionValue) return;
 
-      const companies = await pluginCtx.companies.list({ limit: 1, offset: 0 });
-      const companyId = companies[0]?.id ?? "";
+      const companyId = rt.companyId;
 
       // --- Approval buttons ---
       if (actionId === "approval_approve" || actionId === "approval_reject") {
@@ -1486,13 +1882,15 @@ const plugin = definePlugin({
   },
 
   async onValidateConfig(config) {
-    if (!config.slackTokenRef || typeof config.slackTokenRef !== "string") {
-      return { ok: false, errors: ["slackTokenRef is required"] };
+    const errors = validateSecretRefFields(config as { slackTokenRef?: unknown; slackSigningSecretRef?: unknown });
+    if (
+      !config.defaultChannelId ||
+      typeof config.defaultChannelId !== "string" ||
+      config.defaultChannelId.trim().length === 0
+    ) {
+      errors.push("defaultChannelId is required.");
     }
-    if (!config.defaultChannelId || typeof config.defaultChannelId !== "string") {
-      return { ok: false, errors: ["defaultChannelId is required"] };
-    }
-    return { ok: true };
+    return errors.length > 0 ? { ok: false, errors } : { ok: true };
   },
 
   async onHealth(): Promise<PluginHealthDiagnostics> {

--- a/tests/company-scoped-bootstrap.test.ts
+++ b/tests/company-scoped-bootstrap.test.ts
@@ -322,6 +322,65 @@ describe("bootstrap from a config delivery", () => {
     expect(_getRuntimeForTests()?.companyId).toBe(COMPANY_A);
     expect(await definition().onHealth()).toEqual({ status: "ok" });
   });
+
+  it("keeps the live runtime when the owner's re-save has a broken token", async () => {
+    const host = buildHost();
+    await definition().setup(host.ctx);
+    await host.deliver(COMPANY_A, storedConfig());
+    expect(_getRuntimeForTests()?.token).toBe("xoxb-token");
+
+    // A re-saves with an unresolvable token: the plugin degrades but keeps
+    // serving on the runtime it already has, rather than going fully dark.
+    await host.deliver(COMPANY_A, storedConfig({ slackTokenRef: "" }));
+
+    expect(_getRuntimeForTests()?.companyId).toBe(COMPANY_A);
+    expect(_getRuntimeForTests()?.token).toBe("xoxb-token");
+    expect((await definition().onHealth()).status).toBe("degraded");
+  });
+});
+
+describe("context-less delivery to a running install (720/722)", () => {
+  it("refreshes in place when the running company re-saves without context", async () => {
+    const host = buildHost({
+      companies: [COMPANY_A],
+      rows: { [COMPANY_A]: storedConfig() },
+      enforceInvocationScope: true,
+    });
+    host.setInvocationScope(COMPANY_A);
+    await definition().setup(host.ctx);
+    await definition().onConfigChanged(storedConfig(), { companyId: COMPANY_A });
+    expect(_getRuntimeForTests()?.companyId).toBe(COMPANY_A);
+
+    host.setInvocationScope(COMPANY_A);
+    await definition().onConfigChanged(storedConfig({ defaultChannelId: "C77NEW7NEW7" })); // no context
+    host.setInvocationScope(null);
+
+    expect(_getRuntimeForTests()?.companyId).toBe(COMPANY_A);
+    expect(_getRuntimeForTests()?.config.defaultChannelId).toBe("C77NEW7NEW7");
+  });
+
+  it("leaves the running company untouched when the delivery belongs to another", async () => {
+    const host = buildHost({
+      companies: [COMPANY_A, COMPANY_B],
+      rows: { [COMPANY_A]: storedConfig(), [COMPANY_B]: storedConfig() },
+      enforceInvocationScope: true,
+    });
+    host.setInvocationScope(COMPANY_A);
+    await definition().setup(host.ctx);
+    await definition().onConfigChanged(storedConfig(), { companyId: COMPANY_A });
+    expect(_getRuntimeForTests()?.companyId).toBe(COMPANY_A);
+
+    host.setInvocationScope(COMPANY_B);
+    await definition().onConfigChanged(storedConfig({ defaultChannelId: "C99ZZZ9ZZZ9" })); // no context, B's invocation
+    host.setInvocationScope(null);
+
+    expect(_getRuntimeForTests()?.companyId).toBe(COMPANY_A);
+    expect(_getRuntimeForTests()?.config.defaultChannelId).toBe("C01ABC2DEF3");
+    expect(host.ctx.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(`this install serves ${COMPANY_A}`),
+      expect.objectContaining({ runningCompanyId: COMPANY_A, deliveredCompanyId: COMPANY_B }),
+    );
+  });
 });
 
 describe("single-tenant ownership", () => {

--- a/tests/company-scoped-bootstrap.test.ts
+++ b/tests/company-scoped-bootstrap.test.ts
@@ -515,3 +515,105 @@ describe("webhook fails closed until configured", () => {
     );
   });
 });
+
+describe("round-1 review fixes", () => {
+  it("F1: rejects a slash-command whose parsed body claims type=url_verification", async () => {
+    const host = buildHost();
+    await definition().setup(host.ctx);
+    await host.deliver(COMPANY_A, storedConfig());
+    host.ctx.logger.warn.mockClear();
+
+    // The url_verification exemption must be scoped to the Events endpoint; a
+    // slash-command carrying that body must still be signature-verified.
+    await definition().onWebhook({
+      endpointKey: "slash-command",
+      headers: {},
+      rawBody: "command=/clip&text=status",
+      parsedBody: { type: "url_verification", command: "/clip" },
+      requestId: "req-f1",
+    });
+
+    expect(host.ctx.http.fetch).not.toHaveBeenCalled();
+    expect(host.ctx.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("invalid Slack signature"),
+    );
+  });
+
+  it("F2: the daily digest processes only the owner across multiple visible companies", async () => {
+    const host = buildHost({ companies: [COMPANY_A, COMPANY_B] });
+    await definition().setup(host.ctx);
+    await host.deliver(COMPANY_A, storedConfig({ enableDailyDigest: true }));
+
+    const digest = host.ctx.jobs.register.mock.calls.find((c: any[]) => c[0] === "daily-digest")![1];
+    await digest();
+
+    expect(host.ctx.issues.list).toHaveBeenCalledWith(expect.objectContaining({ companyId: COMPANY_A }));
+    expect(host.ctx.issues.list).not.toHaveBeenCalledWith(expect.objectContaining({ companyId: COMPANY_B }));
+  });
+
+  it("F3: refuses remove_watch from a non-owner company", async () => {
+    const host = buildHost({ companies: [COMPANY_A, COMPANY_B] });
+    await definition().setup(host.ctx);
+    await host.deliver(COMPANY_B, storedConfig());
+
+    const remove = toolHandler(host.ctx, "remove_watch");
+    const result = await remove({ watchId: "watch-x" }, { companyId: COMPANY_A });
+
+    expect(result.error).toMatch(/not configured yet/);
+  });
+
+  it("F4: normalizes a legacy bare-UUID signing-secret ref before resolving", async () => {
+    const host = buildHost();
+    await definition().setup(host.ctx);
+    await host.deliver(COMPANY_A, storedConfig({ slackSigningSecretRef: SIGNING_SECRET_ID }));
+
+    expect(host.ctx.secrets.resolve).toHaveBeenCalledWith(
+      { type: "secret_ref", secretId: SIGNING_SECRET_ID },
+      { companyId: COMPANY_A, configPath: "slackSigningSecretRef" },
+    );
+    expect(_getRuntimeForTests()?.signingSecret).toBe("signing-secret");
+    expect(await definition().onHealth()).toEqual({ status: "ok" });
+  });
+
+  it("F4: builds the runtime but degrades health when the signing secret cannot resolve", async () => {
+    const host = buildHost();
+    host.ctx.secrets.resolve.mockImplementation(async (ref: unknown, opts?: { configPath?: string }) => {
+      if (opts?.configPath === "slackSigningSecretRef") throw new Error("signing resolution failed");
+      if (typeof ref === "string") throw new Error("string refs rejected");
+      return "xoxb-token";
+    });
+    await definition().setup(host.ctx);
+    await host.deliver(COMPANY_A, storedConfig());
+
+    expect(_getRuntimeForTests()?.companyId).toBe(COMPANY_A);
+    expect(_getRuntimeForTests()?.signingSecret).toBeNull();
+    const health = await definition().onHealth();
+    expect(health.status).toBe("degraded");
+    expect(health.message).toMatch(/signing secret/i);
+  });
+
+  it("F5: redacts a resolver error that embeds the supplied secret id", async () => {
+    const host = buildHost();
+    host.ctx.secrets.resolve.mockImplementation(async (ref: unknown) => {
+      throw new Error(`host rejected ${JSON.stringify(ref)} secretId=${(ref as any)?.secretId ?? ref}`);
+    });
+    await definition().setup(host.ctx);
+    await host.deliver(COMPANY_A, storedConfig());
+
+    const diagnostics = await definition().onHealth();
+    expect(diagnostics.status).toBe("degraded");
+    expect(host.everythingSaid(diagnostics)).not.toContain(SECRET_ID);
+  });
+
+  it("F6: a failed refresh that also changes the base URL leaves the retained runtime coherent", async () => {
+    const host = buildHost();
+    await definition().setup(host.ctx);
+    await host.deliver(COMPANY_A, storedConfig());
+    const baseBefore = _getRuntimeForTests()?.baseUrl;
+
+    await host.deliver(COMPANY_A, storedConfig({ slackTokenRef: "", paperclipBaseUrl: "http://changed.invalid:9999" }));
+
+    expect(_getRuntimeForTests()?.companyId).toBe(COMPANY_A);
+    expect(_getRuntimeForTests()?.baseUrl).toBe(baseBefore);
+  });
+});

--- a/tests/company-scoped-bootstrap.test.ts
+++ b/tests/company-scoped-bootstrap.test.ts
@@ -1,0 +1,458 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Company-scoped config bootstrap — issue #31.
+//
+// Since paperclipai/paperclip#9557 (first stable in v2026.720.0) the SDK's
+// governed-access gate requires a company scope for `config.get` and
+// `secrets.resolve`; only `companies.list` is exempt. setup() runs outside any
+// invocation, so a bare `ctx.config.get()` there throws and the worker dies on
+// activation — which is exactly what the Slack plugin used to do.
+//
+// The plugin now registers every handler in setup() unconditionally and builds
+// its runtime only from an `onConfigChanged` delivery, resolving secrets under
+// the company the host attributed the delivery to. These tests pin that on the
+// host generations the plugin must survive. The mocks copy the real host where
+// it bites:
+//   - an unscoped `config.get()` THROWS, it never returns `{}`;
+//   - `secrets.resolve` REJECTS every string secretRef and interpolates the
+//     rejected value into its error (plugin-secrets-handler.ts);
+//   - with `enforceInvocationScope`, a scoped read succeeds only for the company
+//     the current host->worker invocation is bound to (720/722 semantics).
+// ---------------------------------------------------------------------------
+
+const { capturedDefinitions } = vi.hoisted(() => {
+  const capturedDefinitions: any[] = [];
+  return { capturedDefinitions };
+});
+
+vi.mock("@paperclipai/plugin-sdk", () => ({
+  definePlugin: (def: any) => {
+    if (def.setup) capturedDefinitions.push(def);
+    return Object.freeze({ definition: def });
+  },
+  runWorker: vi.fn(),
+}));
+
+import { _resetRuntimeForTests, _getRuntimeForTests } from "../src/worker.js";
+
+const COMPANY_A = "11111111-1111-1111-1111-111111111111";
+const COMPANY_B = "22222222-2222-2222-2222-222222222222";
+const SECRET_ID = "33333333-3333-3333-3333-333333333333";
+const SIGNING_SECRET_ID = "55555555-5555-5555-5555-555555555555";
+
+const UNSCOPED_CONFIG_ERROR =
+  'not allowed to perform "config.get": company context is required';
+
+/** The stored config row the settings picker produces. */
+function storedConfig(overrides: Record<string, unknown> = {}) {
+  return {
+    slackTokenRef: { type: "secret_ref", secretId: SECRET_ID, version: "latest" },
+    slackSigningSecretRef: { type: "secret_ref", secretId: SIGNING_SECRET_ID, version: "latest" },
+    defaultChannelId: "C01ABC2DEF3",
+    enableDailyDigest: false,
+    ...overrides,
+  };
+}
+
+type HostOptions = {
+  companies?: string[];
+  rows?: Record<string, Record<string, unknown>>;
+  denyScopedConfig?: boolean;
+  enforceInvocationScope?: boolean;
+};
+
+function buildHost(options: HostOptions = {}) {
+  const {
+    companies = [COMPANY_A],
+    rows = { [COMPANY_A]: storedConfig() },
+    denyScopedConfig = false,
+    enforceInvocationScope = false,
+  } = options;
+
+  const stateStore = new Map<string, unknown>();
+  const eventHandlers = new Map<string, any[]>();
+  let invocationScope: string | null = null;
+
+  const ctx = {
+    config: {
+      get: vi.fn(async (companyId?: string) => {
+        if (!companyId) throw new Error(UNSCOPED_CONFIG_ERROR);
+        if (enforceInvocationScope) {
+          if (!invocationScope) throw new Error(UNSCOPED_CONFIG_ERROR);
+          if (companyId !== invocationScope) {
+            throw new Error(
+              `requested company "${companyId}" but the current invocation is scoped to company "${invocationScope}"`,
+            );
+          }
+        }
+        if (denyScopedConfig) throw new Error(UNSCOPED_CONFIG_ERROR);
+        return rows[companyId] ?? {};
+      }),
+    },
+    secrets: {
+      resolve: vi.fn(async (secretRef: unknown, opts?: { configPath?: string }) => {
+        if (typeof secretRef === "string") {
+          throw new Error(
+            `Invalid secret reference for plugin: ${secretRef}. Use { type: "secret_ref", secretId, version? }`,
+          );
+        }
+        return opts?.configPath === "slackSigningSecretRef" ? "signing-secret" : "xoxb-token";
+      }),
+    },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    state: {
+      get: vi.fn(async (key: any) => stateStore.get(`${key.scopeKind}:${key.scopeId ?? ""}:${key.stateKey}`) ?? null),
+      set: vi.fn(async (key: any, value: unknown) => {
+        stateStore.set(`${key.scopeKind}:${key.scopeId ?? ""}:${key.stateKey}`, value);
+      }),
+      delete: vi.fn(async () => {}),
+    },
+    metrics: { write: vi.fn() },
+    activity: { log: vi.fn() },
+    jobs: { register: vi.fn() },
+    tools: { register: vi.fn() },
+    data: { register: vi.fn() },
+    actions: { register: vi.fn() },
+    events: {
+      on: vi.fn((name: string, handler: any) => {
+        const list = eventHandlers.get(name) ?? [];
+        list.push(handler);
+        eventHandlers.set(name, list);
+      }),
+      emit: vi.fn(),
+      subscribe: vi.fn(),
+    },
+    companies: {
+      list: vi.fn(async (input?: { limit?: number; offset?: number }) => {
+        const all = companies.map((id) => ({ id, name: `Company ${id.slice(0, 4)}` }));
+        if (!input?.limit) return all;
+        const offset = input.offset ?? 0;
+        return all.slice(offset, offset + input.limit);
+      }),
+    },
+    agents: { list: vi.fn(async () => []), sessions: { sendMessage: vi.fn() } },
+    issues: { list: vi.fn(async () => []) },
+    http: { fetch: vi.fn(async () => ({ ok: true, json: async () => ({}), text: async () => "" })) },
+  } as any;
+
+  return {
+    ctx,
+    async deliver(companyId: string | null, config: Record<string, unknown>, opts?: { withContext?: boolean }) {
+      if (companyId) invocationScope = companyId;
+      try {
+        if (opts?.withContext === false) {
+          await definition().onConfigChanged(config);
+        } else {
+          await definition().onConfigChanged(config, { companyId });
+        }
+      } finally {
+        invocationScope = null;
+      }
+    },
+    setInvocationScope(companyId: string | null) {
+      invocationScope = companyId;
+    },
+    everythingSaid(diagnostics: unknown) {
+      return JSON.stringify([
+        diagnostics,
+        ctx.logger.warn.mock.calls,
+        ctx.logger.error.mock.calls,
+        ctx.logger.info.mock.calls,
+        ctx.logger.debug.mock.calls,
+      ]);
+    },
+  };
+}
+
+function definition(): any {
+  return capturedDefinitions[capturedDefinitions.length - 1];
+}
+
+function toolHandler(ctx: any, name: string) {
+  return ctx.tools.register.mock.calls.find((call: any[]) => call[0] === name)![2];
+}
+
+beforeEach(() => {
+  _resetRuntimeForTests();
+  vi.clearAllMocks();
+});
+
+describe("registration contract", () => {
+  it("registers every handler during setup(), before any config is readable", async () => {
+    const { ctx } = buildHost({ denyScopedConfig: true });
+
+    await definition().setup(ctx);
+
+    const jobKeys = ctx.jobs.register.mock.calls.map((call: any[]) => call[0]);
+    expect(jobKeys).toEqual(
+      expect.arrayContaining(["daily-digest", "check-escalation-timeouts", "check-watches"]),
+    );
+
+    const toolNames = ctx.tools.register.mock.calls.map((call: any[]) => call[0]);
+    expect(toolNames).toEqual(
+      expect.arrayContaining([
+        "escalate_to_human",
+        "handoff_to_agent",
+        "discuss_with_agent",
+        "process_media",
+        "register_command",
+        "register_watch",
+      ]),
+    );
+
+    const actionNames = ctx.actions.register.mock.calls.map((call: any[]) => call[0]);
+    expect(actionNames).toEqual(expect.arrayContaining(["set-channel"]));
+  });
+
+  it("reads nothing at setup(): no unscoped config.get, no secrets.resolve", async () => {
+    const { ctx } = buildHost({ denyScopedConfig: true });
+
+    await expect(definition().setup(ctx)).resolves.toBeUndefined();
+
+    expect(ctx.config.get).not.toHaveBeenCalled();
+    expect(ctx.secrets.resolve).not.toHaveBeenCalled();
+    expect(_getRuntimeForTests()).toBeNull();
+    expect((await definition().onHealth()).status).toBe("degraded");
+  });
+
+  it("tools answer with a clear not-configured error until the runtime exists", async () => {
+    const { ctx } = buildHost({ denyScopedConfig: true });
+    await definition().setup(ctx);
+
+    const escalate = toolHandler(ctx, "escalate_to_human");
+    const result = await escalate({ reason: "why" }, { companyId: COMPANY_A });
+
+    expect(result.error).toMatch(/not configured yet/);
+  });
+});
+
+describe("bootstrap from a config delivery", () => {
+  it("builds the runtime and reports healthy", async () => {
+    const { ctx } = buildHost({ denyScopedConfig: true });
+    await definition().setup(ctx);
+    expect(_getRuntimeForTests()).toBeNull();
+
+    await definition().onConfigChanged(storedConfig(), { companyId: COMPANY_A });
+
+    expect(_getRuntimeForTests()?.companyId).toBe(COMPANY_A);
+    expect(_getRuntimeForTests()?.token).toBe("xoxb-token");
+    expect(_getRuntimeForTests()?.signingSecret).toBe("signing-secret");
+    expect(await definition().onHealth()).toEqual({ status: "ok" });
+  });
+
+  it("resolves the bot token with the company scope and the config path", async () => {
+    const { ctx } = buildHost({ denyScopedConfig: true });
+    await definition().setup(ctx);
+    await definition().onConfigChanged(storedConfig(), { companyId: COMPANY_A });
+
+    expect(ctx.secrets.resolve).toHaveBeenCalledWith(
+      { type: "secret_ref", secretId: SECRET_ID, version: "latest" },
+      { companyId: COMPANY_A, configPath: "slackTokenRef" },
+    );
+    expect(ctx.secrets.resolve).toHaveBeenCalledWith(
+      { type: "secret_ref", secretId: SIGNING_SECRET_ID, version: "latest" },
+      { companyId: COMPANY_A, configPath: "slackSigningSecretRef" },
+    );
+  });
+
+  it("canonicalizes a legacy bare-UUID token reference into the object binding", async () => {
+    const { ctx } = buildHost({ denyScopedConfig: true });
+    await definition().setup(ctx);
+    await definition().onConfigChanged(storedConfig({ slackTokenRef: SECRET_ID }), { companyId: COMPANY_A });
+
+    expect(_getRuntimeForTests()?.companyId).toBe(COMPANY_A);
+    expect(ctx.secrets.resolve).toHaveBeenCalledWith(
+      { type: "secret_ref", secretId: SECRET_ID },
+      { companyId: COMPANY_A, configPath: "slackTokenRef" },
+    );
+  });
+
+  it("refuses a non-UUID token string without echoing the supplied value anywhere", async () => {
+    const RAW = "RAW_SECRET_SENTINEL_do_not_leak";
+    const host = buildHost({ denyScopedConfig: true });
+    await definition().setup(host.ctx);
+    await definition().onConfigChanged(storedConfig({ slackTokenRef: RAW }), { companyId: COMPANY_A });
+
+    expect(_getRuntimeForTests()).toBeNull();
+    expect(host.ctx.secrets.resolve).not.toHaveBeenCalledWith(RAW, expect.anything());
+    const diagnostics = await definition().onHealth();
+    expect(diagnostics.status).toBe("degraded");
+    expect(diagnostics.message).toMatch(/slackTokenRef/);
+    expect(host.everythingSaid(diagnostics)).not.toContain(RAW);
+  });
+
+  it("identifies a context-less delivery by scoped probe, not by list order (720/722)", async () => {
+    const host = buildHost({
+      companies: [COMPANY_A, COMPANY_B],
+      rows: { [COMPANY_B]: storedConfig() },
+      enforceInvocationScope: true,
+    });
+    await definition().setup(host.ctx);
+
+    host.setInvocationScope(COMPANY_B);
+    await definition().onConfigChanged(storedConfig()); // no context
+    host.setInvocationScope(null);
+
+    expect(_getRuntimeForTests()?.companyId).toBe(COMPANY_B);
+    expect(host.ctx.secrets.resolve).toHaveBeenCalledWith(expect.anything(), {
+      companyId: COMPANY_B,
+      configPath: "slackTokenRef",
+    });
+  });
+
+  it("degrades with a clear message when no company scope can be identified", async () => {
+    const { ctx } = buildHost({ companies: [COMPANY_A, COMPANY_B], denyScopedConfig: true });
+    await definition().setup(ctx);
+
+    await definition().onConfigChanged(storedConfig(), { companyId: null });
+
+    expect(_getRuntimeForTests()).toBeNull();
+    expect((await definition().onHealth()).message).toMatch(/company/i);
+  });
+
+  it("recovers the owner on its next valid save after a failed bootstrap", async () => {
+    const host = buildHost({ denyScopedConfig: true });
+    await definition().setup(host.ctx);
+
+    await definition().onConfigChanged(storedConfig({ slackTokenRef: "" }), { companyId: COMPANY_A });
+    expect(_getRuntimeForTests()).toBeNull();
+
+    await definition().onConfigChanged(storedConfig(), { companyId: COMPANY_A });
+    expect(_getRuntimeForTests()?.companyId).toBe(COMPANY_A);
+    expect(await definition().onHealth()).toEqual({ status: "ok" });
+  });
+});
+
+describe("single-tenant ownership", () => {
+  it("keeps the first delivered company and refuses a different one", async () => {
+    const host = buildHost({ companies: [COMPANY_A, COMPANY_B] });
+    await definition().setup(host.ctx);
+
+    await host.deliver(COMPANY_A, storedConfig());
+    await host.deliver(COMPANY_B, storedConfig({ defaultChannelId: "C99ZZZ9ZZZ9" }));
+
+    expect(_getRuntimeForTests()?.companyId).toBe(COMPANY_A);
+    expect(_getRuntimeForTests()?.config.defaultChannelId).toBe("C01ABC2DEF3");
+    expect(host.ctx.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(`this install serves ${COMPANY_A}`),
+      expect.objectContaining({ deliveredCompanyId: COMPANY_B }),
+    );
+  });
+
+  it("advances the owner on an identical configuration, as the host's guard does", async () => {
+    const host = buildHost({ companies: [COMPANY_A, COMPANY_B] });
+    await definition().setup(host.ctx);
+
+    const duplicated = storedConfig();
+    await host.deliver(COMPANY_A, duplicated);
+    await host.deliver(COMPANY_B, { ...duplicated });
+
+    expect(_getRuntimeForTests()?.companyId).toBe(COMPANY_B);
+    expect(host.ctx.logger.info).toHaveBeenCalledWith(
+      expect.stringContaining("owner advancing"),
+      expect.objectContaining({ previousCompanyId: COMPANY_A, companyId: COMPANY_B }),
+    );
+  });
+
+  it("re-applies config in place on the owner's own subsequent save", async () => {
+    const host = buildHost();
+    await definition().setup(host.ctx);
+    await host.deliver(COMPANY_A, storedConfig());
+
+    await host.deliver(COMPANY_A, storedConfig({ defaultChannelId: "C77NEW7NEW7" }));
+
+    expect(_getRuntimeForTests()?.companyId).toBe(COMPANY_A);
+    expect(_getRuntimeForTests()?.config.defaultChannelId).toBe("C77NEW7NEW7");
+  });
+
+  it("serializes two back-to-back saves; the last one wins", async () => {
+    const host = buildHost({ rows: {} });
+    await definition().setup(host.ctx);
+
+    const first = definition().onConfigChanged(storedConfig(), { companyId: COMPANY_A });
+    const second = definition().onConfigChanged(
+      storedConfig({ defaultChannelId: "C88LAST8LST" }),
+      { companyId: COMPANY_A },
+    );
+    await Promise.all([first, second]);
+
+    expect(_getRuntimeForTests()?.companyId).toBe(COMPANY_A);
+    expect(_getRuntimeForTests()?.config.defaultChannelId).toBe("C88LAST8LST");
+  });
+});
+
+describe("host-authoritative company scoping", () => {
+  it("refuses a tool invocation from a company that is not the owner", async () => {
+    const host = buildHost({ companies: [COMPANY_A, COMPANY_B] });
+    await definition().setup(host.ctx);
+    await host.deliver(COMPANY_B, storedConfig());
+
+    const escalate = toolHandler(host.ctx, "escalate_to_human");
+    const result = await escalate({ reason: "why" }, { companyId: COMPANY_A });
+
+    expect(result.error).toMatch(/not configured yet/);
+    expect(host.ctx.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(`this install serves ${COMPANY_B}`),
+      expect.objectContaining({ invokingCompanyId: COMPANY_A }),
+    );
+  });
+});
+
+describe("webhook fails closed until configured", () => {
+  it("rejects a non-verification webhook before bootstrap", async () => {
+    const { ctx } = buildHost({ denyScopedConfig: true });
+    await definition().setup(ctx);
+
+    await definition().onWebhook({
+      endpointKey: "slash-command",
+      headers: {},
+      rawBody: "command=/clip&text=status",
+      parsedBody: { command: "/clip" },
+      requestId: "req-1",
+    });
+
+    expect(ctx.http.fetch).not.toHaveBeenCalled();
+    expect(ctx.metrics.write).not.toHaveBeenCalled();
+    expect(ctx.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("not configured yet"),
+    );
+  });
+
+  it("lets the Slack URL-verification handshake through without a runtime", async () => {
+    const { ctx } = buildHost({ denyScopedConfig: true });
+    await definition().setup(ctx);
+
+    await expect(
+      definition().onWebhook({
+        endpointKey: "slack-events",
+        headers: {},
+        rawBody: JSON.stringify({ type: "url_verification", challenge: "abc" }),
+        parsedBody: { type: "url_verification", challenge: "abc" },
+        requestId: "req-2",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(ctx.logger.warn).not.toHaveBeenCalledWith(expect.stringContaining("not configured yet"));
+  });
+
+  it("rejects an unsigned webhook after bootstrap (signature required)", async () => {
+    const host = buildHost();
+    await definition().setup(host.ctx);
+    await host.deliver(COMPANY_A, storedConfig());
+    host.ctx.logger.warn.mockClear();
+
+    await definition().onWebhook({
+      endpointKey: "slash-command",
+      headers: {},
+      rawBody: "command=/clip&text=status",
+      parsedBody: { command: "/clip" },
+      requestId: "req-3",
+    });
+
+    expect(host.ctx.http.fetch).not.toHaveBeenCalled();
+    expect(host.ctx.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("invalid Slack signature"),
+    );
+  });
+});

--- a/tests/config-hot-reload.test.ts
+++ b/tests/config-hot-reload.test.ts
@@ -7,9 +7,12 @@ import { describe, it, expect, beforeEach } from "vitest";
 // with `if (config.notifyOnAgentConnected)`. Toggling the flag in the UI had
 // no effect until the worker restarted.
 //
-// The fix: handlers are always registered; each handler calls ctx.config.get()
-// at invocation time. These tests replicate that pattern and verify that
-// disabling a flag mid-flight silences subsequent events.
+// The fix: handlers are always registered and each reads the live config at
+// invocation time. Under company scoping that live config is the runtime the
+// host rebuilds on every `onConfigChanged` delivery (a saved flag change is
+// re-delivered), rather than a per-invocation ctx.config.get(). These tests
+// replicate the read-live-each-time pattern and verify that disabling a flag
+// mid-flight silences subsequent events.
 // ---------------------------------------------------------------------------
 
 type Config = {

--- a/tests/manifest-contract.test.ts
+++ b/tests/manifest-contract.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import manifest from "../src/manifest.js";
+
+// The secret picker on current Paperclip hosts binds an OBJECT-shaped secret
+// reference; older hosts persist a bare UUID string. A manifest that declares
+// only "string" makes the two mutually unsatisfiable and the plugin becomes
+// unconfigurable on one of them (the exact issue the sibling plugins hit).
+describe("manifest secret-ref contract", () => {
+  const props = manifest.instanceConfigSchema.properties as Record<string, any>;
+
+  for (const key of ["slackTokenRef", "slackSigningSecretRef"]) {
+    it(`declares ${key} as a string|object secret ref`, () => {
+      expect(props[key].type).toEqual(["string", "object"]);
+      expect(props[key].format).toBe("secret-ref");
+    });
+  }
+
+  it("accepts additional properties so a delivered config with extra keys validates", () => {
+    expect((manifest.instanceConfigSchema as any).additionalProperties).toBe(true);
+  });
+
+  it("requires the token, signing secret, and default channel", () => {
+    expect(manifest.instanceConfigSchema.required).toEqual(
+      expect.arrayContaining(["slackTokenRef", "slackSigningSecretRef", "defaultChannelId"]),
+    );
+  });
+
+  it("declares no companyId config field (the company is host-authoritative)", () => {
+    expect(props.companyId).toBeUndefined();
+  });
+});

--- a/tests/proactive-suggestions.test.ts
+++ b/tests/proactive-suggestions.test.ts
@@ -1,6 +1,56 @@
-import { describe, it, expect } from "vitest";
-import { BUILTIN_WATCH_TEMPLATES } from "../src/proactive-suggestions.js";
+import { describe, it, expect, vi } from "vitest";
+import type { PluginContext } from "@paperclipai/plugin-sdk";
+import {
+  BUILTIN_WATCH_TEMPLATES,
+  registerWatch,
+  removeWatch,
+  listWatches,
+} from "../src/proactive-suggestions.js";
 import { isMediaFile, isAudioFile } from "../src/media-pipeline.js";
+
+function stateCtx(): PluginContext {
+  const store = new Map<string, unknown>();
+  const key = (k: any) => `${k.scopeKind}:${k.scopeId ?? ""}:${k.stateKey}`;
+  return {
+    state: {
+      get: vi.fn(async (k: any) => store.get(key(k)) ?? null),
+      set: vi.fn(async (k: any, v: unknown) => { store.set(key(k), v); }),
+    },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  } as unknown as PluginContext;
+}
+
+const COMPANY_A = "11111111-1111-1111-1111-111111111111";
+const COMPANY_B = "22222222-2222-2222-2222-222222222222";
+
+describe("watch registry tenancy (F3)", () => {
+  it("does not let one company delete another company's watch by id", async () => {
+    const ctx = stateCtx();
+    const watchA = await registerWatch(ctx, COMPANY_A, {
+      companyId: COMPANY_A, channelId: "C1", threadTs: "", eventPattern: "issue.created",
+      agentId: "agent", prompt: "p", createdBy: "tool",
+    });
+
+    // Company B tries to remove company A's watch by its id.
+    const removed = await removeWatch(ctx, watchA.id, COMPANY_B);
+
+    expect(removed).toBe(false);
+    expect(await listWatches(ctx, COMPANY_A)).toHaveLength(1);
+  });
+
+  it("lets the owning company delete its own watch", async () => {
+    const ctx = stateCtx();
+    const watchA = await registerWatch(ctx, COMPANY_A, {
+      companyId: COMPANY_A, channelId: "C1", threadTs: "", eventPattern: "issue.created",
+      agentId: "agent", prompt: "p", createdBy: "tool",
+    });
+
+    const removed = await removeWatch(ctx, watchA.id, COMPANY_A);
+
+    expect(removed).toBe(true);
+    expect(await listWatches(ctx, COMPANY_A)).toHaveLength(0);
+  });
+});
 
 describe("BUILTIN_WATCH_TEMPLATES", () => {
   it("has 5 built-in templates", () => {

--- a/tests/runtime-token.test.ts
+++ b/tests/runtime-token.test.ts
@@ -1,13 +1,14 @@
 import { describe, expect, it, vi } from "vitest";
 import type { PluginContext } from "@paperclipai/plugin-sdk";
 import {
-  SECRET_RESOLUTION_DISABLED_MESSAGE,
   SECRET_RESOLUTION_ISSUE_URL,
   resolveStartupSlackToken,
   type SlackRuntimeHealth,
 } from "../src/runtime-token.js";
 
-function makeContext(resolve: () => Promise<string>): PluginContext {
+const TOKEN_UUID = "12f7ed4a-1234-4d0c-9abc-bd58d44d15e1";
+
+function makeContext(resolve: (...args: unknown[]) => Promise<string>): PluginContext {
   return {
     secrets: { resolve },
     logger: {
@@ -17,37 +18,43 @@ function makeContext(resolve: () => Promise<string>): PluginContext {
 }
 
 describe("resolveStartupSlackToken", () => {
-  it("returns the resolved Slack token and marks health ok", async () => {
+  it("normalizes a bare UUID ref and resolves it under the delivered company scope", async () => {
     const health: SlackRuntimeHealth[] = [];
-    const ctx = makeContext(async () => "xoxb-token");
+    const resolve = vi.fn(async () => "xoxb-token");
+    const ctx = makeContext(resolve);
 
-    const token = await resolveStartupSlackToken(ctx, "secret-ref", (next) => health.push(next));
+    const token = await resolveStartupSlackToken(ctx, TOKEN_UUID, (next) => health.push(next), "company-1");
 
     expect(token).toBe("xoxb-token");
     expect(health).toEqual([{ status: "ok" }]);
+    expect(resolve).toHaveBeenCalledWith(
+      { type: "secret_ref", secretId: TOKEN_UUID },
+      { companyId: "company-1", configPath: "slackTokenRef" },
+    );
   });
 
   it("degrades health and does not throw when Paperclip secret resolution fails", async () => {
     const health: SlackRuntimeHealth[] = [];
     const ctx = makeContext(async () => {
-      throw new Error(SECRET_RESOLUTION_DISABLED_MESSAGE);
+      throw new Error("boom");
     });
 
-    const token = await resolveStartupSlackToken(ctx, "secret-ref", (next) => health.push(next));
+    const token = await resolveStartupSlackToken(ctx, TOKEN_UUID, (next) => health.push(next), "company-1");
 
     expect(token).toBeUndefined();
     expect(health).toEqual([{
       status: "degraded",
-      message: SECRET_RESOLUTION_DISABLED_MESSAGE,
+      message: "Slack bot token secret resolution failed: Error: boom",
       details: {
-        issue: "paperclip-plugin-secret-resolution-disabled",
+        issue: "slack-bot-token-resolution-failed",
         reference: SECRET_RESOLUTION_ISSUE_URL,
+        error: "Error: boom",
       },
     }]);
     expect(ctx.logger.error).toHaveBeenCalledWith(
       "Slack plugin cannot resolve Slack token secret; runtime features are disabled",
       {
-        error: `Error: ${SECRET_RESOLUTION_DISABLED_MESSAGE}`,
+        error: "Error: boom",
         reference: SECRET_RESOLUTION_ISSUE_URL,
       },
     );

--- a/tests/secret-ref-validation.test.ts
+++ b/tests/secret-ref-validation.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import {
+  isValidSecretRef,
+  normalizeSecretRef,
+  normalizeSecretRefId,
+  isUsableSecretRef,
+  validateSecretRefFields,
+} from "../src/secret-ref-validation.js";
+
+const UUID = "12f7ed4a-1234-4d0c-9abc-bd58d44d15e1";
+const OTHER_UUID = "99999999-9999-4999-8999-999999999999";
+
+describe("isValidSecretRef", () => {
+  it("accepts a bare UUID string and an object ref", () => {
+    expect(isValidSecretRef(UUID)).toBe(true);
+    expect(isValidSecretRef({ type: "secret_ref", secretId: UUID })).toBe(true);
+    expect(isValidSecretRef({ type: "secret_ref", secretId: UUID, version: 2 })).toBe(true);
+  });
+
+  it("rejects a raw token, an empty value, and a malformed object", () => {
+    expect(isValidSecretRef("xoxb-not-a-uuid")).toBe(false);
+    expect(isValidSecretRef("")).toBe(false);
+    expect(isValidSecretRef(undefined)).toBe(false);
+    expect(isValidSecretRef({ type: "secret_ref", secretId: "nope" })).toBe(false);
+    expect(isValidSecretRef({ secretId: UUID })).toBe(false);
+  });
+});
+
+describe("normalizeSecretRef", () => {
+  it("coerces a bare UUID string into the object binding the host requires", () => {
+    expect(normalizeSecretRef(UUID)).toEqual({ type: "secret_ref", secretId: UUID });
+  });
+
+  it("passes a valid object ref through unchanged", () => {
+    const ref = { type: "secret_ref", secretId: UUID, version: 3 };
+    expect(normalizeSecretRef(ref)).toBe(ref);
+  });
+
+  it("returns null for anything unusable", () => {
+    expect(normalizeSecretRef("raw-token")).toBeNull();
+    expect(normalizeSecretRef(undefined)).toBeNull();
+    expect(normalizeSecretRef({ secretId: UUID })).toBeNull();
+  });
+});
+
+describe("normalizeSecretRefId", () => {
+  it("extracts the bare UUID from either shape", () => {
+    expect(normalizeSecretRefId(UUID)).toBe(UUID);
+    expect(normalizeSecretRefId({ type: "secret_ref", secretId: UUID })).toBe(UUID);
+    expect(normalizeSecretRefId("not-a-uuid")).toBeNull();
+    expect(normalizeSecretRefId(null)).toBeNull();
+  });
+});
+
+describe("isUsableSecretRef", () => {
+  it("is true only for a resolvable ref", () => {
+    expect(isUsableSecretRef(UUID)).toBe(true);
+    expect(isUsableSecretRef({ type: "secret_ref", secretId: UUID })).toBe(true);
+    expect(isUsableSecretRef("")).toBe(false);
+    expect(isUsableSecretRef(undefined)).toBe(false);
+  });
+});
+
+describe("validateSecretRefFields", () => {
+  it("passes when both required refs are valid", () => {
+    expect(
+      validateSecretRefFields({
+        slackTokenRef: UUID,
+        slackSigningSecretRef: { type: "secret_ref", secretId: OTHER_UUID },
+      }),
+    ).toEqual([]);
+  });
+
+  it("flags a missing required ref", () => {
+    const errors = validateSecretRefFields({ slackSigningSecretRef: UUID });
+    expect(errors).toContain("slackTokenRef is required.");
+  });
+
+  it("flags a malformed ref without echoing the raw value", () => {
+    const errors = validateSecretRefFields({
+      slackTokenRef: "xoxb-raw-token-do-not-leak-xxxxxxxx",
+      slackSigningSecretRef: UUID,
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatch(/slackTokenRef must be the UUID/);
+    expect(errors[0]).not.toContain("xoxb-raw-token-do-not-leak-xxxxxxxx");
+  });
+});

--- a/tests/secret-ref-validation.test.ts
+++ b/tests/secret-ref-validation.test.ts
@@ -4,6 +4,7 @@ import {
   normalizeSecretRef,
   normalizeSecretRefId,
   isUsableSecretRef,
+  redactSecretRefs,
   validateSecretRefFields,
 } from "../src/secret-ref-validation.js";
 
@@ -83,6 +84,27 @@ describe("validateSecretRefFields", () => {
     });
     expect(errors).toHaveLength(1);
     expect(errors[0]).toMatch(/slackTokenRef must be the UUID/);
-    expect(errors[0]).not.toContain("xoxb-raw-token-do-not-leak-xxxxxxxx");
+    // Not even a prefix of the pasted value may appear.
+    expect(errors[0]).not.toContain("xoxb");
+  });
+});
+
+describe("redactSecretRefs", () => {
+  it("strips an object ref's secretId, its JSON form, and a raw string ref", () => {
+    const objMsg = `host rejected ${JSON.stringify({ type: "secret_ref", secretId: UUID })} secretId=${UUID}`;
+    const redactedObj = redactSecretRefs(objMsg, { type: "secret_ref", secretId: UUID });
+    expect(redactedObj).not.toContain(UUID);
+    expect(redactedObj).toContain("[redacted]");
+
+    const strMsg = `Invalid secret reference for plugin: raw-token-value-123456`;
+    const redactedStr = redactSecretRefs(strMsg, "raw-token-value-123456");
+    expect(redactedStr).not.toContain("raw-token-value-123456");
+    expect(redactedStr).toContain("[redacted]");
+  });
+
+  it("leaves an unrelated message untouched", () => {
+    expect(redactSecretRefs("company context is required", UUID)).toBe(
+      "company context is required",
+    );
   });
 });


### PR DESCRIPTION
## What

Reworks the Slack plugin to the **deliveries-only company-scoping** pattern already shipped in the telegram, discord, and acp plugins, so it activates on governed Paperclip hosts (≥ v2026.720.0, paperclipai/paperclip#9557). Closes #31.

`setup()` no longer reads config or resolves secrets (those calls are denied outside a company scope and were killing activation). The runtime is built solely from `onConfigChanged` — handling both the ≥ v2026.817.0 two-arg (context) delivery and the v2026.720/722 context-less scoped-probe path — under single-tenant ownership. Every tool/event/job/webhook handler is gated on `ensureRuntime()` and no-ops until a delivery builds it.

## Notable

- **SDK bump** `2026.618.0 → 2026.817.0` (parity with discord/acp) for the scoped `config.get(companyId)` / `secrets.resolve(ref, {companyId})` / two-arg `onConfigChanged` surfaces.
- `onWebhook` now **fails closed** on signature verification (was: skip when no signing secret); the `url_verification` exemption is scoped to the Events endpoint only.
- Manifest secret-refs widened to `["string", "object"]` + worker-side normalization, so the object-shaped binding current hosts produce validates (and legacy bare-UUID refs still resolve).
- Scheduled jobs operate strictly on the owner company — no cross-tenant token or data use.

## Review

Independent DEEP review (Codex `gpt-5.6-sol`): initial **BLOCK** (4 MAJOR, including a signature-verification bypass and a cross-tenant credential leak) → all findings fixed in-slice → **PASS-WITH-RESIDUALS, 0 blockers, 0 new findings**.

## Gates

`typecheck` · **157 tests** · `build` — all green.

## Sequencing

This activation fix lands **before #29**. It has no dependency on Socket Mode; #29 will rebase on this company-scoped runtime and retain its existing review requirements. Fresh verification at `59b3d80` passes typecheck, 157 tests, and build. This restores company-scoped activation; it does not resolve the separate upstream webhook transport gaps.

---
<sub><em>**[@superbiche](https://github.com/superbiche)** · co-maintainer · drafted with Claude Opus 4.8, reviewed before posting; the voice and decisions are mine.</em></sub>


<sub>Sequencing updated with Codex GPT-6, reviewed by Michel before posting.</sub>
